### PR TITLE
Add some labels and a badge linking to image on Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,7 @@ ADD dist/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY _build/kube-lego /kube-lego
 COPY README.md /README.md
 CMD ["/kube-lego"]
+ARG VCS_REF
+LABEL org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/jetstack/kube-lego" \
+      org.label-schema.license="Apache-2.0"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ node('docker'){
         sh "make docker_build"
 
         stage 'Build docker image'
-        sh "docker build -t ${imageName}:${imageTag} ."
+        sh "docker build --build-arg VCS_REF=${gitCommit().take(8)} -t ${imageName}:${imageTag} ."
 
         if (onMasterBranch()) {
             stage 'Push docker image'

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ TEST_DIR=_test
 
 CONTAINER_DIR=/go/src/${PACKAGE_NAME}
 
+.PHONY: version
+
 depend:
 	rm -rf $(TEST_DIR)/
 	rm -rf ${BUILD_DIR}/
@@ -18,8 +20,8 @@ depend:
 	mkdir $(BUILD_DIR)/
 	which godep || go get github.com/tools/godep
 
-version:
-	$(eval GIT_STATE := $(shell if test -z "`git status --porcelain 2> /dev/null`"; then echo -n "clean"; else echo -n "dirty"; fi))
+version: 
+	$(eval GIT_STATE := $(shell if test -z "`git status --porcelain 2> /dev/null`"; then echo "clean"; else echo "dirty"; fi))
 	$(eval GIT_COMMIT := $(shell git rev-parse HEAD))
 	$(eval APP_VERSION := $(shell cat VERSION))
 
@@ -70,8 +72,8 @@ docker_%:
 	# remove container
 	docker rm $(CONTAINER_ID)
 
-image: docker_all
-	docker build -t $(ACCOUNT)/$(APP_NAME):latest .
+image: docker_all version
+	docker build --build-arg VCS_REF=$(GIT_COMMIT) -t $(ACCOUNT)/$(APP_NAME):latest .
 	
 push: image
 	docker push $(ACCOUNT)/$(APP_NAME):latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 *kube-lego* automatically requests certificates for Kubernetes Ingress resources from Let's Encrypt
 
 [![Build Status](https://travis-ci.org/jetstack/kube-lego.svg?branch=master)](https://travis-ci.org/jetstack/kube-lego)
+[![](https://images.microbadger.com/badges/version/jetstack/kube-lego.svg)](http://microbadger.com/#/images/jetstack/kube-lego "Get your own version badge on microbadger.com")
 
 ## Screencast
 


### PR DESCRIPTION
Hi Jetstack folks! You might have heard we're working with some folks in the container community on a [standard label schema](http://label-schema.org), and a tool called [MicroBadger](microbadger.com) that lets you inspect image metadata and get badges for your GitHub and Docker Hub pages. 

To get momentum we want to encourage as many people as possible to label their public container images. Here's a PR that will label your image automatically as part of your existing build process.

I will fess up that I have not tested the Jenkins build change but I guess we'll see what happens in the automated build when I submit this PR :-) 

Was nice to see Matt at AWS last week! 