### PR TITLE
ObtainCert: Add error logging to retry loop

### DIFF
--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -88,6 +88,11 @@ func (a *Acme) ObtainCertificate(domains []string) (data map[string][]byte, err 
 
 	op := func() error {
 		data, err = a.obtainCertificate(domains)
+		
+		if err != nil {
+			a.Log().Warn("Error while obtaining certificate: ", err)
+		}
+		
 		return err
 	}
 


### PR DESCRIPTION
I was running into a loop where the certificate would be requested repeatedly and then I would get rate limiting error before finding out what the error with the certificate was.

This way the errors from ACME are logged.

```
2016/08/16 20:31:54 [INFO][example.com] acme: Obtaining bundled SAN certificate
2016/08/16 20:31:55 [INFO][example.com] acme: Could not find solver for: tls-sni-01
2016/08/16 20:31:55 [INFO][example.com] acme: Could not find solver for: dns-01
2016/08/16 20:31:55 [INFO][example.com] acme: Trying to solve HTTP-01
2016/08/16 20:31:55 [INFO][example.com] The server validated our request
2016/08/16 20:31:55 [INFO][example.com] acme: Validations succeeded; requesting certificates
time="2016-08-16T20:31:58Z" level=debug msg="testing reachablity of http://example.com/.well-known/acme-challenge/_selftest" context=acme host=example.com
2016/08/16 20:31:58 [INFO][example.com] acme: Obtaining bundled SAN certificate
2016/08/16 20:31:58 [INFO][example.com] acme: Could not find solver for: tls-sni-01
2016/08/16 20:31:58 [INFO][example.com] acme: Could not find solver for: dns-01
2016/08/16 20:31:58 [INFO][example.com] acme: Trying to solve HTTP-01
2016/08/16 20:31:58 [INFO][example.com] The server validated our request
2016/08/16 20:31:58 [INFO][example.com] acme: Validations succeeded; requesting certificates
time="2016-08-16T20:32:02Z" level=debug msg="testing reachablity of http://example.com/.well-known/acme-challenge/_selftest" context=acme host=example.com
2016/08/16 20:32:02 [INFO][example.com] acme: Obtaining bundled SAN certificate
2016/08/16 20:32:03 [INFO][example.com] acme: Could not find solver for: tls-sni-01
2016/08/16 20:32:03 [INFO][example.com] acme: Could not find solver for: dns-01
2016/08/16 20:32:03 [INFO][example.com] acme: Trying to solve HTTP-01
2016/08/16 20:32:03 [INFO][example.com] The server validated our request
2016/08/16 20:32:03 [INFO][example.com] acme: Validations succeeded; requesting certificates
time="2016-08-16T20:32:08Z" level=debug msg="testing reachablity of http://example.com/.well-known/acme-challenge/_selftest" context=acme host=example.com
2016/08/16 20:32:08 [INFO][example.com] acme: Obtaining bundled SAN certificate
2016/08/16 20:32:09 [INFO][example.com] acme: Could not find solver for: tls-sni-01
2016/08/16 20:32:09 [INFO][example.com] acme: Could not find solver for: dns-01
2016/08/16 20:32:09 [INFO][example.com] acme: Trying to solve HTTP-01
2016/08/16 20:32:09 [INFO][example.com] The server validated our request
2016/08/16 20:32:09 [INFO][example.com] acme: Validations succeeded; requesting certificates
```