### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@
 
 ### run kube-lego
 
-- [deployment](examples/gce/50-kube-lego-deployment.yaml) for *kube-lego*
-  - don't forget to configure
-     - `LEGO_EMAIL` with your mail address
-     - `LEGO_POD_IP` with the pod IP address using the downward API
-  - the default value of `LEGO_URL` is the Let's Encrypt **staging environment**. If you want to get "real" certificates you have to configure their production env.
+[deployment](examples/gce/50-kube-lego-deployment.yaml) for *kube-lego*
+
+- don't forget to configure
+   - `LEGO_EMAIL` with your mail address
+   - `LEGO_POD_IP` with the pod IP address using the downward API
+- the default value of `LEGO_URL` is the Let's Encrypt **staging environment**. If you want to get "real" certificates you have to configure their production env.
 
 ### how kube-lego works
 
@@ -102,8 +103,9 @@ spec:
 
 ## Full deployment examples
 
-- [Nginx Ingress Controller](https://github.com/jetstack/kube-lego/blob/master/examples/nginx/README.md)
-- [GCE Load Balancers](https://github.com/jetstack/kube-lego/blob/master/examples/gce/README.md)
+[Nginx Ingress Controller](examples/nginx/README.md)
+
+[GCE Load Balancers](examples/gce/README.md)
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ spec:
 
 ## Full deployment examples
 
-- [Nginx Ingress Controller](examples/nginx/README.md)
-- [GCE Load Balancers](examples/gce/README.md)
+- [Nginx Ingress Controller](https://github.com/jetstack/kube-lego/blob/master/examples/nginx/README.md)
+- [GCE Load Balancers](https://github.com/jetstack/kube-lego/blob/master/examples/gce/README.md)
 
 ## Authors
 


### PR DESCRIPTION
From `https://github.com/jetstack/kube-lego`, the link to `examples/nginx/README.md` means the link to `https://github.com/jetstack/examples/nginx/README.md` and this returns 404.

Work-around for https://github.com/isaacs/github/issues/766