### PR TITLE
Fixing a few typos

### DIFF
--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -49,7 +49,7 @@ func (a *Acme) testReachablilty(domain string) error {
 	url.Host = domain
 	url.Path = kubelego.AcmeHttpSelfTest
 
-	a.Log().WithField("domain", domain).Debugf("testing reachablity of %s", url.String())
+	a.Log().WithField("domain", domain).Debugf("testing reachability of %s", url.String())
 	response, err := http.Get(url.String())
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (a *Acme) testReachablilty(domain string) error {
 func (a *Acme) verifyDomain(domain string) (auth *acme.Authorization, err error) {
 	err = a.testReachablilty(domain)
 	if err != nil {
-		return nil, fmt.Errorf("reachabily test failed: %s", err)
+		return nil, fmt.Errorf("reachability test failed: %s", err)
 	}
 
 	auth, err = a.acmeClient.Authorize(context.Background(), domain)
@@ -93,13 +93,13 @@ func (a *Acme) verifyDomain(domain string) (auth *acme.Authorization, err error)
 	}
 
 	if challenge == nil {
-		return nil, fmt.Errorf("no http-01 challege was offered")
+		return nil, fmt.Errorf("no http-01 challenge was offered")
 	}
 
 	token := challenge.Token
 	key, err := a.acmeClient.HTTP01ChallengeResponse(token)
 	if err != nil {
-		return nil, fmt.Errorf("error generating http-01 repsonse: %s", err)
+		return nil, fmt.Errorf("error generating http-01 response: %s", err)
 	}
 
 	a.Present(domain, token, key)

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -30,11 +30,11 @@ func IgnoreIngress(ing *k8sExtensions.Ingress) error {
 	val, ok := ing.Annotations[key]
 
 	if !ok {
-		return fmt.Errorf("has no annotiation '%s'", key)
+		return fmt.Errorf("has no annotation '%s'", key)
 	}
 
 	if strings.ToLower(val) != "true" {
-		return fmt.Errorf("annotiation '%s' is not true", key)
+		return fmt.Errorf("annotation '%s' is not true", key)
 	}
 
 	return nil
@@ -59,7 +59,7 @@ func New(client kubelego.KubeLego, namespace string, name string) *Ingress {
 			ingress.exists = false
 
 		} else {
-			client.Log().Warn("Error during getting secret: ", err)
+			client.Log().Warn("Error while getting secret: ", err)
 		}
 	}
 

--- a/pkg/ingress/tls_suite_test.go
+++ b/pkg/ingress/tls_suite_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Tls", func() {
 					tls.newCertNeeded(),
 				).To(Equal(true))
 			})
-			It("should be true for validity below minium validity", func() {
+			It("should be true for validity below minimum validity", func() {
 				mockSec.EXPECT().TlsExpireTime().AnyTimes().Return(
 					time.Now().Add(48*time.Hour),
 					nil,

--- a/pkg/kubelego/configure.go
+++ b/pkg/kubelego/configure.go
@@ -99,14 +99,14 @@ func (kl *KubeLego) reconfigure(ingressesAll []kubelego.Ingress) error {
 	tlsSlice = kl.TlsIgnoreDuplicatedSecrets(tlsSlice)
 
 	// process certificate validity
-	kl.Log().Info("process certificates requests for ingresses")
+	kl.Log().Info("process certificate requests for ingresses")
 	errs := kl.TlsProcessHosts(tlsSlice)
 	if len(errs) > 0 {
 		errsStr := []string{}
 		for _, err := range errs {
 			errsStr = append(errsStr, fmt.Sprintf("%s", err))
 		}
-		kl.Log().Error("Error while process certificate requests: ", strings.Join(errsStr, ", "))
+		kl.Log().Error("Error while processing certificate requests: ", strings.Join(errsStr, ", "))
 
 		// request a rerun of reconfigure
 		kl.workQueue.Add(true)

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -54,7 +54,7 @@ func (kl *KubeLego) Log() *log.Entry {
 }
 
 func (kl *KubeLego) Stop() {
-	kl.Log().Info("shuting things down")
+	kl.Log().Info("shutting things down")
 	close(kl.stopCh)
 }
 

--- a/pkg/mocks/ingress.go
+++ b/pkg/mocks/ingress.go
@@ -60,7 +60,7 @@ func BasicIngressDomain12Challenge12() *k8sExtensions.Ingress {
 	ing := BasicIngressDomain12()
 	ing.Name = "ingress-domain12-challenge12"
 
-	challengeRule := BasicIngressRule("unused", "/.well-known/acme-challenge/*", BasicIngressBackend("kube-lege-gce", 8080))
+	challengeRule := BasicIngressRule("unused", "/.well-known/acme-challenge/*", BasicIngressBackend("kube-lego-gce", 8080))
 
 	ing.Spec.Rules[0].HTTP.Paths = append(challengeRule.HTTP.Paths, ing.Spec.Rules[0].HTTP.Paths...)
 	ing.Spec.Rules[1].HTTP.Paths = append(challengeRule.HTTP.Paths, ing.Spec.Rules[1].HTTP.Paths...)

--- a/pkg/provider/gce/gce.go
+++ b/pkg/provider/gce/gce.go
@@ -54,7 +54,7 @@ func (p *Gce) Reset() (err error) {
 }
 
 func (p *Gce) Finalize() (err error) {
-	p.Log().Debug("finialize")
+	p.Log().Debug("finalize")
 
 	err = p.updateServices()
 	if err != nil {

--- a/pkg/provider/gce/gce_suite_test.go
+++ b/pkg/provider/gce/gce_suite_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Gce", func() {
 				Expect(provider.usedByNamespace).To(HaveKeyWithValue(ing.ObjectMeta.Namespace, true))
 			})
 		})
-		Context("Ingress with with challenge rules domain12 and no tls", func() {
+		Context("Ingress with challenge rules domain12 and no tls", func() {
 			BeforeEach(func() {
 				mockIng = mocks.DummyIngressDomain12Challenge12(ctrlMock, mocks.DummyTlsEmpty(ctrlMock))
 				ing = mockIng.Object()

--- a/pkg/provider/nginx/nginx.go
+++ b/pkg/provider/nginx/nginx.go
@@ -37,7 +37,7 @@ func (p *Nginx) Reset() error {
 }
 
 func (p *Nginx) Finalize() error {
-	p.Log().Debug("finialize")
+	p.Log().Debug("finalize")
 
 	if p.ingress == nil {
 		p.ingress = ingress.New(p.kubelego, p.kubelego.LegoNamespace(), p.kubelego.LegoIngressNameNginx())

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -33,7 +33,7 @@ func New(client kubelego.KubeLego, namespace string, name string) *Secret {
 			secret.Log().Info("creating new secret")
 			secret.exists = false
 		} else {
-			client.Log().Warn("Error during getting secret: ", err)
+			client.Log().Warn("Error while getting secret: ", err)
 		}
 	}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -37,7 +37,7 @@ func New(client kubelego.KubeLego, namespace string, name string) *Service {
 			service.exists = false
 
 		} else {
-			client.Log().Warn("Error during getting service: ", err)
+			client.Log().Warn("Error while getting service: ", err)
 		}
 	}
 
@@ -57,7 +57,7 @@ func (s *Service) Delete() error {
 	val, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
 	if !ok || val != "true" {
 		return fmt.Errorf(
-			"do not delete service '%s/%s' as it has no %s annotiation",
+			"do not delete service '%s/%s' as it has no %s annotation",
 			s.ServiceApi.Namespace,
 			s.ServiceApi.Name,
 			kubelego.AnnotationKubeLegoManaged,


### PR DESCRIPTION
This commit just fixes a few typos / inconsistencies in log message strings and should have no other impact. The only exception is the fix in`pkg/mocks/ingress.go` (probably didn't work before ?)