### PR TITLE
Better links for full deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ spec:
 
 ## Full deployment examples
 
-- [Nginx Ingress Controller](examples/nginx/README.md)
-- [GCE Load Balancers](examples/gce/README.md)
+- [Nginx Ingress Controller](examples/nginx/)
+- [GCE Load Balancers](examples/gce/)
 
 ## Authors
 


### PR DESCRIPTION
It is easier to read when inside the folder than just seeing the readme as this readme refers to files in the folder.