### PR TITLE
change image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM scratch
-ADD dist/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM alpine:3.5
+RUN apk --update add ca-certificates && rm -rf /var/cache/apk/*
 COPY _build/kube-lego /kube-lego
 COPY README.md /README.md
 CMD ["/kube-lego"]


### PR DESCRIPTION
Fix kube-lego crashing #71 

Same as https://github.com/funktionio/funktion/pull/32

The image size just increased 4MB
```
kube-lego-alpine                                  latest              ea7ca4b996df        11 hours ago        65 MB
kube-lego-scratch                                 latest              36e6953dc0f6        12 hours ago        61 MB
```