### PR TITLE
Add ability to customize ingress class

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ spec:
 | `LEGO_SECRET_NAME` | n | `kube-lego-account` | Name of the secret in the same namespace that contains ACME account secret |
 | `LEGO_SERVICE_NAME_NGINX` | n | `kube-lego-nginx` | Service name for NGINX ingress |
 | `LEGO_SERVICE_NAME_GCE` | n | `kube-lego-gce` | Service name for GCE ingress |
+| `LEGO_SUPPORTED_INGRESS_CLASS` | n | `nginx,gce` | Specify the supported ingress class |
 | `LEGO_INGRESS_NAME_NGINX` | n | `kube-lego-nginx` | Ingress name which contains the routing for HTTP verification for nginx ingress |
 | `LEGO_PORT` | n | `8080` | Port where this daemon is listening for verifcation calls (HTTP method)|
 | `LEGO_CHECK_INTERVAL` | n | `8h` | Interval for periodically certificate checks (to find expired certs)|

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -14,14 +14,14 @@ import (
 	k8sExtensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
-func IsSupportedIngressClass(in string) (out string, err error) {
+func IsSupportedIngressClass(supportedClass []string, in string) (out string, err error) {
 	out = strings.ToLower(in)
-	for _, ingClass := range kubelego.SupportedIngressClasses {
+	for _, ingClass := range supportedClass {
 		if ingClass == out {
 			return out, nil
 		}
 	}
-	return "", fmt.Errorf("unsupported ingress class '%s'", in)
+	return "", fmt.Errorf("unsupported ingress class '%s'. Did you you forget to specify LEGO_DEFAULT_INGRESS_CLASS ?", in)
 }
 
 func IgnoreIngress(ing *k8sExtensions.Ingress) error {
@@ -170,7 +170,7 @@ func (i *Ingress) Ignore() bool {
 		return true
 	}
 
-	_, err = IsSupportedIngressClass(i.IngressClass())
+	_, err = IsSupportedIngressClass(i.kubelego.LegoSupportedIngressClass(), i.IngressClass())
 	if err != nil {
 		i.Log().Info("ignoring as ", err)
 		return true

--- a/pkg/ingress/ingress_test.go
+++ b/pkg/ingress/ingress_test.go
@@ -8,16 +8,18 @@ import (
 )
 
 func TestIsSupportedIngressClass(t *testing.T) {
-	out, err := IsSupportedIngressClass("Nginx")
+	supportedClass := []string{"nginx","gce","custom"}
+	out, err := IsSupportedIngressClass(supportedClass,"Nginx")
 	assert.Equal(t, "nginx", out)
 	assert.Nil(t, err)
 
-	out, err = IsSupportedIngressClass("customlb")
+	out, err = IsSupportedIngressClass(supportedClass,"customlb")
 	assert.NotNil(t, err)
 
-	out, err = IsSupportedIngressClass("gce")
+	out, err = IsSupportedIngressClass(supportedClass,"gce")
 	assert.Equal(t, "gce", out)
 	assert.Nil(t, err)
+
 }
 
 func TestIngress_Tls(t *testing.T) {

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -167,6 +167,9 @@ func (kl *KubeLego) LegoDefaultIngressClass() string {
 func (kl *KubeLego) LegoIngressNameNginx() string {
 	return kl.legoIngressNameNginx
 }
+func (kl *KubeLego) LegoSupportedIngressClass() []string {
+	return kl.legoSupportedIngressClass
+}
 
 func (kl *KubeLego) LegoServiceNameNginx() string {
 	return kl.legoServiceNameNginx
@@ -247,12 +250,17 @@ func (kl *KubeLego) paramsLego() error {
 		kl.legoServiceNameGce = "kube-lego-gce"
 	}
 
+	kl.legoSupportedIngressClass = strings.Split(os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS"),",")
+	if len(kl.legoSupportedIngressClass) == 1 {
+		kl.legoSupportedIngressClass = kubelego.SupportedIngressClasses
+	}
+
 	legoDefaultIngressClass := os.Getenv("LEGO_DEFAULT_INGRESS_CLASS")
 	if len(legoDefaultIngressClass) == 0 {
 		kl.legoDefaultIngressClass = "nginx"
 	} else {
 		var err error = nil
-		kl.legoDefaultIngressClass, err = ingress.IsSupportedIngressClass(legoDefaultIngressClass)
+		kl.legoDefaultIngressClass, err = ingress.IsSupportedIngressClass(kl.legoSupportedIngressClass, legoDefaultIngressClass)
 		if err != nil {
 			return fmt.Errorf("Unsupported default ingress class: '%s'", legoDefaultIngressClass)
 		}

--- a/pkg/kubelego/type.go
+++ b/pkg/kubelego/type.go
@@ -14,24 +14,25 @@ import (
 )
 
 type KubeLego struct {
-	legoURL                 string
-	legoEmail               string
-	legoSecretName          string
-	legoIngressNameNginx    string
-	legoNamespace           string
-	legoPodIP               net.IP
-	legoServiceNameNginx    string
-	legoServiceNameGce      string
-	legoHTTPPort            intstr.IntOrString
-	legoCheckInterval       time.Duration
-	legoMinimumValidity     time.Duration
-	legoDefaultIngressClass string
-	legoKubeApiURL          string
-	kubeClient              *kubernetes.Clientset
-	legoIngressSlice        []*ingress.Ingress
-	legoIngressProvider     map[string]kubelego.IngressProvider
-	version                 string
-	acmeClient              kubelego.Acme
+	legoURL                   string
+	legoEmail                 string
+	legoSecretName            string
+	legoIngressNameNginx      string
+	legoNamespace             string
+	legoPodIP                 net.IP
+	legoServiceNameNginx      string
+	legoServiceNameGce        string
+	legoSupportedIngressClass []string
+	legoHTTPPort              intstr.IntOrString
+	legoCheckInterval         time.Duration
+	legoMinimumValidity       time.Duration
+	legoDefaultIngressClass   string
+	legoKubeApiURL            string
+	kubeClient                *kubernetes.Clientset
+	legoIngressSlice          []*ingress.Ingress
+	legoIngressProvider       map[string]kubelego.IngressProvider
+	version                   string
+	acmeClient                kubelego.Acme
 
 	// stop channel for services
 	stopCh chan struct{}

--- a/pkg/kubelego_const/interfaces.go
+++ b/pkg/kubelego_const/interfaces.go
@@ -23,6 +23,7 @@ type KubeLego interface {
 	LegoServiceNameNginx() string
 	LegoServiceNameGce() string
 	LegoDefaultIngressClass() string
+	LegoSupportedIngressClass() []string
 	LegoCheckInterval() time.Duration
 	LegoMinimumValidity() time.Duration
 	LegoPodIP() net.IP

--- a/pkg/mocks/mocks.go
+++ b/pkg/mocks/mocks.go
@@ -142,6 +142,12 @@ func (_m *MockKubeLego) LegoDefaultIngressClass() string {
 	return ret0
 }
 
+func (_m *MockKubeLego) LegoSupportedIngressClass() []string {
+	ret := _m.ctrl.Call(_m, "LegoSupportedIngressClass")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
 func (_mr *_MockKubeLegoRecorder) LegoDefaultIngressClass() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoDefaultIngressClass")
 }

--- a/pkg/provider/nginx/nginx.go
+++ b/pkg/provider/nginx/nginx.go
@@ -119,7 +119,7 @@ func (p *Nginx) updateIngress() error {
 	ing.Annotations = map[string]string{
 		kubelego.AnnotationIngressChallengeEndpoints: "true",
 		kubelego.AnnotationSslRedirect:               "false",
-		kubelego.AnnotationIngressClass:              "nginx",
+		kubelego.AnnotationIngressClass:              p.kubelego.LegoDefaultIngressClass(),
 	}
 
 	ing.Spec = k8sExtensions.IngressSpec{


### PR DESCRIPTION
I'm restricting my ingresses to internal and external traffic. To do this, I'm running 2 ingress with  [ingress--class] (https://github.com/kubernetes/ingress/blob/6cd21f7dea61e4df694d62857d5ea31f442962ce/core/pkg/ingress/controller/launch.go#L43) option.

When I finished the setup, I realise that kube-lego start ignoring my certificates with this message below.
```
time="2017-03-07T14:59:21Z" level=info msg="ignoring as unsupported ingress class 'intern'" context=ingress name=kibana namespace=log
```

This PR add the ability to kube-lego to work with different class (default: nginx,gce).

Ex:

```LEGO_SUPPORTED_INGRESS_CLASS="intern,extern,nginx,custom"```