### PR TITLE
add support for running multiple instance of kube-lego in the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ spec:
 | `LEGO_DEFAULT_INGRESS_CLASS` | n | `nginx` | Default ingress class for resources without specification|
 | `LEGO_KUBE_API_URL` | n | `http://127.0.0.1:8080` | API server URL |
 | `LEGO_LOG_LEVEL` | n | `info` | Set log level (`debug|info|warn|error`) |
+| `LEGO_KUBE_ANNOTATION` | n | `kubernetes.io/tls-acme` | Set the ingress annotation used by this instance of kube-lego to get certificate for from Let's Encrypt. Allows you to run kube-lego against staging and production LE |
 
 
 ## Full deployment examples

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -312,5 +312,10 @@ func (kl *KubeLego) paramsLego() error {
 		kl.legoHTTPPort = intstr.FromInt(i)
 	}
 
+	annotationEnabled := os.Getenv("LEGO_KUBE_ANNOTATION")
+	if len(annotationEnabled) == 0 {
+		kubelego.AnnotationEnabled = annotationEnabled
+	}
+
 	return nil
 }

--- a/pkg/kubelego_const/consts.go
+++ b/pkg/kubelego_const/consts.go
@@ -18,8 +18,8 @@ const TLSCaKey = "ca.crt"
 const AnnotationIngressChallengeEndpoints = "kubernetes.io/tls-acme-challenge-endpoints"
 const AnnotationIngressChallengeEndpointsHash = "kubernetes.io/tls-acme-challenge-endpoints-hash"
 const AnnotationIngressClass = "kubernetes.io/ingress.class"
-const AnnotationEnabled = "kubernetes.io/tls-acme"
 const AnnotationSslRedirect = "ingress.kubernetes.io/ssl-redirect"
 const AnnotationKubeLegoManaged = "kubernetes.io/kube-lego-managed"
 
 var SupportedIngressClasses = []string{"nginx", "gce"}
+var AnnotationEnabled = "kubernetes.io/tls-acme"


### PR DESCRIPTION
This enables kube-lego to watch its configured annotation and getting certificate from corresponding LE provider.

For running with staging LE, the annotation can be the default one or `kubernetes.io/tls-acme-staging` and for production `kubernetes.io/tls-acme-production`. This will avoid people running into unnecessary LE rate limit by avoiding asking for certs from production until they really need it.

This will close #50 