### PR TITLE
fix empty annotation

### DIFF
--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -250,7 +250,7 @@ func (kl *KubeLego) paramsLego() error {
 		kl.legoServiceNameGce = "kube-lego-gce"
 	}
 
-	kl.legoSupportedIngressClass = strings.Split(os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS"),",")
+	kl.legoSupportedIngressClass = strings.Split(os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS"), ",")
 	if len(kl.legoSupportedIngressClass) == 1 {
 		kl.legoSupportedIngressClass = kubelego.SupportedIngressClasses
 	}
@@ -322,6 +322,8 @@ func (kl *KubeLego) paramsLego() error {
 
 	annotationEnabled := os.Getenv("LEGO_KUBE_ANNOTATION")
 	if len(annotationEnabled) == 0 {
+		kubelego.AnnotationEnabled = kubelego.DefaultAnnotationEnabled
+	} else {
 		kubelego.AnnotationEnabled = annotationEnabled
 	}
 

--- a/pkg/kubelego_const/consts.go
+++ b/pkg/kubelego_const/consts.go
@@ -10,6 +10,7 @@ const AcmeRegistrationUrl = "acme-registration-url"
 const AcmePrivateKey = k8sApi.TLSPrivateKeyKey
 const AcmeHttpChallengePath = "/.well-known/acme-challenge"
 const AcmeHttpSelfTest = "/.well-known/acme-challenge/_selftest"
+const DefaultAnnotationEnabled = "kubernetes.io/tls-acme"
 
 const TLSCertKey = k8sApi.TLSCertKey
 const TLSPrivateKeyKey = k8sApi.TLSPrivateKeyKey


### PR DESCRIPTION
PR #105 was not filling the default annotation if env LEGO_KUBE_ANNOTATION is empty.

I’m not sure, but looks like the behaviour of LEGO_KUBE_ANNOTATION is the same when you have 2+ kube-lego instances running with different LEGO_DEFAULT_INGRESS_CLASS.

# production ingress 
```
apiVersion: v1
items:
- apiVersion: extensions/v1beta1
  kind: Ingress
  metadata:
    annotations:
      ingress.kubernetes.io/ssl-redirect: "false"
      kubernetes.io/ingress.class: production
      kubernetes.io/tls-acme: "true"
```
# staging ingress

```
apiVersion: v1
items:
- apiVersion: extensions/v1beta1
  kind: Ingress
  metadata:
    annotations:
      ingress.kubernetes.io/ssl-redirect: "false"
      kubernetes.io/ingress.class: staging
      kubernetes.io/tls-acme: "true"
```

@gurvindersingh WDYT?
