### PR TITLE
fix logic typo

### DIFF
--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -321,7 +321,7 @@ func (kl *KubeLego) paramsLego() error {
 	}
 
 	annotationEnabled := os.Getenv("LEGO_KUBE_ANNOTATION")
-	if len(annotationEnabled) == 0 {
+	if len(annotationEnabled) != 0 {
 		kubelego.AnnotationEnabled = annotationEnabled
 	}
 


### PR DESCRIPTION
Before this fix AnnotationEnabled would be set to the empty string,
causing kube-lego to ignore all events.