### PR TITLE
Set the ENTRYPOINT instead of the CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 RUN apk --update add ca-certificates && rm -rf /var/cache/apk/*
 COPY _build/kube-lego /kube-lego
 COPY README.md /README.md
-CMD ["/kube-lego"]
+ENTRYPOINT ["/kube-lego"]
 ARG VCS_REF
 LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/jetstack/kube-lego" \


### PR DESCRIPTION
This makes it possible to just provide arguments to kube-lego, rather than having
to know where in the image the binary actually is.