### PR TITLE
Configure the log.Entry instance once

### DIFF
--- a/pkg/kubelego/configure_test.go
+++ b/pkg/kubelego/configure_test.go
@@ -69,7 +69,7 @@ func getTlsExample() []kubelego.Tls {
 }
 
 func TestKubeLego_TlsIgnoreDuplicatedSecrets(t *testing.T) {
-	k := KubeLego{}
+	k := New("test")
 	input := getTlsExample()
 	output := k.TlsIgnoreDuplicatedSecrets(input)
 	assert.EqualValues(t, 2, len(output))

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -27,15 +27,7 @@ import (
 
 var _ kubelego.KubeLego = &KubeLego{}
 
-func New(version string) *KubeLego {
-	return &KubeLego{
-		version:   version,
-		stopCh:    make(chan struct{}),
-		waitGroup: sync.WaitGroup{},
-	}
-}
-
-func (kl *KubeLego) Log() *log.Entry {
+func makeLog() *log.Entry {
 	loglevel := strings.ToLower(os.Getenv("LEGO_LOG_LEVEL"))
 	if len(loglevel) == 0 {
 		log.SetLevel(log.InfoLevel)
@@ -51,6 +43,19 @@ func (kl *KubeLego) Log() *log.Entry {
 		log.SetLevel(log.InfoLevel)
 	}
 	return log.WithField("context", "kubelego")
+}
+
+func New(version string) *KubeLego {
+	return &KubeLego{
+		version:   version,
+		log:       makeLog(),
+		stopCh:    make(chan struct{}),
+		waitGroup: sync.WaitGroup{},
+	}
+}
+
+func (kl *KubeLego) Log() *log.Entry {
+	return kl.log
 }
 
 func (kl *KubeLego) Stop() {

--- a/pkg/kubelego/type.go
+++ b/pkg/kubelego/type.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/jetstack/kube-lego/pkg/ingress"
 	"github.com/jetstack/kube-lego/pkg/kubelego_const"
 
@@ -31,6 +32,7 @@ type KubeLego struct {
 	kubeClient                *kubernetes.Clientset
 	legoIngressSlice          []*ingress.Ingress
 	legoIngressProvider       map[string]kubelego.IngressProvider
+	log                       *log.Entry
 	version                   string
 	acmeClient                kubelego.Acme
 


### PR DESCRIPTION
KubeLego's Log() function used to get and parse the LEGO_LOG_LEVEL environment
variable for every call, and then create an instance with the correct context set.
This is highly useless: environment variables should never change while a program
is running.