### PR TITLE
Parse any command line arguments using flag.Parse

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/jetstack/kube-lego/pkg/kubelego"
 )
 
@@ -22,6 +24,9 @@ func Version() string {
 }
 
 func main() {
+	// parse standard command line arguments
+	flag.Parse()
+
 	kl := kubelego.New(Version())
 	kl.Init()
 }


### PR DESCRIPTION
kube-lego doesn't have arguments, but doing the parsing here allows to enable
flags for imported packages (such as enabling logging of the kubernetes client!)