### PR TITLE
Add ability to only monitor a single namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Please note:
 | `LEGO_KUBE_API_URL` | n | `http://127.0.0.1:8080` | API server URL |
 | `LEGO_LOG_LEVEL` | n | `info` | Set log level (`debug|info|warn|error`) |
 | `LEGO_KUBE_ANNOTATION` | n | `kubernetes.io/tls-acme` | Set the ingress annotation used by this instance of kube-lego to get certificate for from Let's Encrypt. Allows you to run kube-lego against staging and production LE |
+| `LEGO_WATCH_NAMESPACE` | n | `` | Namespace that kube-lego should watch for ingresses and services |
 
 ## Full deployment examples
 

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -10,7 +10,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sExtensionsTyped "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
-	k8sApi "k8s.io/client-go/pkg/api/v1"
 	k8sExtensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
@@ -68,7 +67,7 @@ func New(client kubelego.KubeLego, namespace string, name string) *Ingress {
 }
 
 func All(client kubelego.KubeLego) (ingresses []kubelego.Ingress, err error) {
-	ingSlice, err := client.KubeClient().Extensions().Ingresses(k8sApi.NamespaceAll).List(k8sMeta.ListOptions{})
+	ingSlice, err := client.KubeClient().Extensions().Ingresses(client.LegoWatchNamespace()).List(k8sMeta.ListOptions{})
 
 	if err != nil {
 		return

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -325,5 +325,11 @@ func (kl *KubeLego) paramsLego() error {
 		kubelego.AnnotationEnabled = annotationEnabled
 	}
 
+	watchNamespace := os.Getenv("LEGO_WATCH_NAMESPACE")
+	if len(watchNamespace) == 0 {
+		kl.legoWatchNamespace = k8sApi.NamespaceAll
+	} else {
+		kl.legoWatchNamespace = watchNamespace
+	}
 	return nil
 }

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -156,6 +156,10 @@ func (kl *KubeLego) LegoNamespace() string {
 	return kl.legoNamespace
 }
 
+func (kl *KubeLego) LegoWatchNamespace() string {
+	return kl.legoWatchNamespace
+}
+
 func (kl *KubeLego) LegoPodIP() net.IP {
 	return kl.legoPodIP
 }

--- a/pkg/kubelego/type.go
+++ b/pkg/kubelego/type.go
@@ -28,6 +28,7 @@ type KubeLego struct {
 	legoMinimumValidity       time.Duration
 	legoDefaultIngressClass   string
 	legoKubeApiURL            string
+	legoWatchNamespace        string
 	kubeClient                *kubernetes.Clientset
 	legoIngressSlice          []*ingress.Ingress
 	legoIngressProvider       map[string]kubelego.IngressProvider

--- a/pkg/kubelego/watch.go
+++ b/pkg/kubelego/watch.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	k8sApi "k8s.io/client-go/pkg/api/v1"
 	k8sExtensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -95,8 +94,8 @@ func (kl *KubeLego) WatchEvents() {
 
 	_, controller := cache.NewInformer(
 		&cache.ListWatch{
-			ListFunc:  ingressListFunc(kl.kubeClient, k8sApi.NamespaceAll),
-			WatchFunc: ingressWatchFunc(kl.kubeClient, k8sApi.NamespaceAll),
+			ListFunc:  ingressListFunc(kl.kubeClient, kl.legoWatchNamespace),
+			WatchFunc: ingressWatchFunc(kl.kubeClient, kl.legoWatchNamespace),
 		},
 		&k8sExtensions.Ingress{},
 		resyncPeriod,

--- a/pkg/kubelego_const/interfaces.go
+++ b/pkg/kubelego_const/interfaces.go
@@ -19,6 +19,7 @@ type KubeLego interface {
 	LegoEmail() string
 	LegoURL() string
 	LegoNamespace() string
+	LegoWatchNamespace() string
 	LegoIngressNameNginx() string
 	LegoServiceNameNginx() string
 	LegoServiceNameGce() string

--- a/pkg/mocks/kubelego.go
+++ b/pkg/mocks/kubelego.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/golang/mock/gomock"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sApi "k8s.io/client-go/pkg/api/v1"
 )
 
 func DummyKubeLego(c *gomock.Controller) *MockKubeLego {
@@ -17,6 +18,7 @@ func DummyKubeLego(c *gomock.Controller) *MockKubeLego {
 	kl.EXPECT().Log().AnyTimes().Return(log)
 	kl.EXPECT().LegoHTTPPort().AnyTimes().Return(intstr.FromInt(8080))
 	kl.EXPECT().LegoNamespace().AnyTimes().Return("kube-lego")
+	kl.EXPECT().LegoWatchNamespace().AnyTimes().Return(k8sApi.NamespaceAll)
 	kl.EXPECT().LegoPodIP().AnyTimes().Return(net.ParseIP("1.2.3.4"))
 	kl.EXPECT().LegoIngressNameNginx().AnyTimes().Return("kube-lego-nginx")
 	kl.EXPECT().LegoServiceNameNginx().AnyTimes().Return("kube-lego-nginx")

--- a/pkg/mocks/mocks.go
+++ b/pkg/mocks/mocks.go
@@ -106,6 +106,16 @@ func (_mr *_MockKubeLegoRecorder) LegoNamespace() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoNamespace")
 }
 
+func (_m *MockKubeLego) LegoWatchNamespace() string {
+	ret := _m.ctrl.Call(_m, "LegoWatchNamespace")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockKubeLegoRecorder) LegoWatchNamespace() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoWatchNamespace")
+}
+
 func (_m *MockKubeLego) LegoIngressNameNginx() string {
 	ret := _m.ctrl.Call(_m, "LegoIngressNameNginx")
 	ret0, _ := ret[0].(string)


### PR DESCRIPTION
When the LEGO_WATCH_NAMESPACE environment variable is set to a non-empty value then kube-lego
will only monitor that namespace rather than all namespaces.