### PR TITLE
Change ingress paths from / to /* in gce example

### DIFF
--- a/examples/gce/echoserver/ingress-notls.yaml
+++ b/examples/gce/echoserver/ingress-notls.yaml
@@ -15,7 +15,7 @@ spec:
   - host: echo.example.com
     http:
       paths:
-      - path: /
+      - path: /*
         backend:
           serviceName: echoserver
           servicePort: 80

--- a/examples/gce/echoserver/ingress-tls.yaml
+++ b/examples/gce/echoserver/ingress-tls.yaml
@@ -15,7 +15,7 @@ spec:
   - host: echo.example.com
     http:
       paths:
-      - path: /
+      - path: /*
         backend:
           serviceName: echoserver
           servicePort: 80


### PR DESCRIPTION
Without this, paths outside the root such as `/foo` point to the default backend. Fixes #115.