### PR TITLE
Fix the order of namespace/name in the secret names

### DIFF
--- a/pkg/kubelego/configure.go
+++ b/pkg/kubelego/configure.go
@@ -15,8 +15,8 @@ func (kl *KubeLego) TlsIgnoreDuplicatedSecrets(tlsSlice []kubelego.Tls) []kubele
 	for _, elm := range tlsSlice {
 		key := fmt.Sprintf(
 			"%s/%s",
-			elm.SecretMetadata().Name,
 			elm.SecretMetadata().Namespace,
+			elm.SecretMetadata().Name,
 		)
 		tlsBySecert[key] = append(
 			tlsBySecert[key],


### PR DESCRIPTION
This makes the warning message less confusing by using the typical
order of namespace/name rather than name/namespace.