### PR TITLE
Associate app: kube-lego selector with k8s service

### DIFF
--- a/pkg/provider/gce/gce.go
+++ b/pkg/provider/gce/gce.go
@@ -87,7 +87,9 @@ func (p *Gce) updateService(namespace string) (err error) {
 
 	svc.SetKubeLegoSpec()
 	svc.Object().Spec.Type = "NodePort"
-	svc.Object().Spec.Selector = map[string]string{}
+	svc.Object().Spec.Selector = map[string]string{
+		"app": "kube-lego",
+	}
 
 	podIP := p.kubelego.LegoPodIP().String()
 	p.Log().WithField("pod_ip", podIP).WithField("namespace", namespace).Debug("setting up svc endpoint")


### PR DESCRIPTION
This fixes GCE reachability failures (502 error code)