### PR TITLE
Fix suppressed error while ACME client creation

### DIFF
--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -117,7 +117,8 @@ func (a *Acme) verifyDomain(domain string) (auth *acme.Authorization, err error)
 }
 
 func (a *Acme) ObtainCertificate(domains []string) (data map[string][]byte, err error) {
-	if a.ensureAcmeClient() != nil {
+	err = a.ensureAcmeClient()
+	if err != nil {
 		return data, err
 	}
 


### PR DESCRIPTION
This should solve these errors:

> Required value, data[tls.key]: Required value]" context=kubelego
