### PR TITLE
Change text under "run kube-lego"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@
 
 ### run kube-lego
 
-- [deployment](examples/gce/lego/deployment.yaml) for *kube-lego*
-  - don't forget to configure
-     - `LEGO_EMAIL` with your mail address
-     - `LEGO_POD_IP` with the pod IP address using the downward API
-  - the default value of `LEGO_URL` is the Let's Encrypt **staging environment**. If you want to get "real" certificates you have to configure their production env.
+* [GCE](examples/gce/README.md)
+* [nginx controller](examples/nginx/README.md)
+
+The default value of `LEGO_URL` is the Let's Encrypt **staging environment**. If you want to get "real" certificates you have to configure their production env.
 
 ### how kube-lego works
 


### PR DESCRIPTION
1. Remove details about deployment.yaml et al
2. Link directly to GCE/nginx example README
3. Keep the bit about looking ag LE staging by default

fixes #157 
fixes #158
If this is merged, PR #166 should be closed and ignored.