### PR TITLE
Checks for Host header when issuing selftest

### DIFF
--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -73,7 +73,28 @@ func (a *Acme) testReachablilty(domain string) error {
 	return nil
 }
 
+func (a *Acme) enableDomainVerification(domain string) {
+	a.domainsMutex.Lock()
+	a.domainsToVerify[domain] = struct{}{}
+	a.domainsMutex.Unlock()
+}
+
+func (a *Acme) disableDomainVerification(domain string) {
+	a.domainsMutex.Lock()
+	delete(a.domainsToVerify, domain)
+	a.domainsMutex.Unlock()
+}
+
+func (a *Acme) domainToVerifyExists(domain string) bool {
+	a.domainsMutex.RLock()
+	_, ok := a.domainsToVerify[domain]
+	a.domainsMutex.RUnlock()
+	return ok
+}
+
 func (a *Acme) verifyDomain(domain string) (auth *acme.Authorization, err error) {
+	a.enableDomainVerification(domain)
+	defer a.disableDomainVerification(domain)
 	err = a.testReachablilty(domain)
 	if err != nil {
 		return nil, fmt.Errorf("reachability test failed: %s", err)

--- a/pkg/acme/type.go
+++ b/pkg/acme/type.go
@@ -23,6 +23,9 @@ type Acme struct {
 	challengesHostToToken map[string]string
 	challengesTokenToKey  map[string]string
 
+	domainsMutex    sync.RWMutex
+	domainsToVerify map[string]struct{}
+
 	notFound string // string displayed for 404 messages
 	id       string // identification (random string)
 


### PR DESCRIPTION
1. Upon request to verifyDomain(), we record the domain that
we would like to test for reacheability
2. The selftest handler does a check on the Host header value
against this domain name. it returns 200 if the domain is present,
and 404 otherwise
3. Once the verifyDomain() test is done, this record is erased,
ensuring that future requests to the selftest endpoing returns 404

fixes #163