### PR TITLE
Added sample RBAC

### DIFF
--- a/examples/gce/README.md
+++ b/examples/gce/README.md
@@ -13,6 +13,8 @@ kubectl apply -f lego/00-namespace.yaml
 kubectl apply -f lego/configmap.yaml
 # Deployment
 kubectl apply -f lego/deployment.yaml
+# RBAC role & binding
+kubectl apply -f lego/rbac.yaml
 # Service is created by kube-lego in every used namespace
 ```
 

--- a/examples/gce/lego/rbac.yaml
+++ b/examples/gce/lego/rbac.yaml
@@ -1,0 +1,41 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: ingress-secret-admin
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - patch
+- apiGroups: [""]
+  resources: ["services"]
+  verbs:
+  - get
+  - create
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-lego
+roleRef:
+  kind: ClusterRole
+  name: ingress-secret-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-lego

--- a/examples/nginx/README.md
+++ b/examples/nginx/README.md
@@ -52,6 +52,7 @@ kubectl apply -f echoserver/ingress-notls.yaml
 ```
 kubectl apply -f lego/configmap.yaml
 kubectl apply -f lego/deployment.yaml
+kubectl apply -f lego/rbac.yaml
 ```
 - Change the email address in `kube-lego-configmap.yaml` before creating the
   kubernetes resource

--- a/examples/nginx/lego/rbac.yaml
+++ b/examples/nginx/lego/rbac.yaml
@@ -1,0 +1,41 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: ingress-secret-admin
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - patch
+- apiGroups: [""]
+  resources: ["services"]
+  verbs:
+  - get
+  - create
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-lego
+roleRef:
+  kind: ClusterRole
+  name: ingress-secret-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-lego


### PR DESCRIPTION
Initial RBAC sample. Likely way too permissive.
Also note that examples/nginx/lego/rbac.yaml only includes the
configuration for kube-lego itself, not nginx-ingress.