### PR TITLE
Do not crash when cannot verifying LE user

### DIFF
--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -37,6 +37,7 @@ func (a *Acme) ensureAcmeClient() error {
 	account, err := a.validateUser(client, accountURI)
 	if err != nil {
 		a.Log().Fatalf("fatal error verifying existing user: %s", err)
+		return err
 	}
 	a.acmeAccount = account
 	a.acmeClient = client

--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -36,7 +36,7 @@ func (a *Acme) ensureAcmeClient() error {
 
 	account, err := a.validateUser(client, accountURI)
 	if err != nil {
-		a.Log().Fatalf("fatal error verifying existing user: %s", err)
+		a.Log().Errorf("fatal error verifying existing user: %s", err)
 		return err
 	}
 	a.acmeAccount = account


### PR DESCRIPTION
Try to fix #185 
Return an error when cannot verifying LE user. I'm not go developer, maybe my patch is not working :smile: 