### PR TITLE
Ingress providers setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Please note:
 | `LEGO_SERVICE_NAME_GCE` | n | `kube-lego-gce` | Service name for GCE ingress |
 | `LEGO_SUPPORTED_INGRESS_CLASS` | n | `nginx,gce` | Specify the supported ingress class |
 | `LEGO_INGRESS_NAME_NGINX` | n | `kube-lego-nginx` | Ingress name which contains the routing for HTTP verification for nginx ingress |
+| `LEGO_INGRESS_PROVIDERS` | n | `nginx,gce` | Specify the supported ingress providers. Valid values are: "nginx" and "gce" |
 | `LEGO_PORT` | n | `8080` | Port where this daemon is listening for verifcation calls (HTTP method)|
 | `LEGO_CHECK_INTERVAL` | n | `8h` | Interval for periodically certificate checks (to find expired certs)|
 | `LEGO_MINIMUM_VALIDITY` | n | `720h` (30 days) | Request a renewal when the remaining certificate validity falls below that value|


### PR DESCRIPTION
This PR introduces the `LEGO_INGRESS_PROVIDERS` environment variable to customize the desired providers to be loaded, current valid options: `gce` and `nginx`.

Related to #192