### PR TITLE
fix(pkg/kubelego) do not match ingress class with provider name

### DIFF
--- a/pkg/kubelego/configure.go
+++ b/pkg/kubelego/configure.go
@@ -63,11 +63,14 @@ func (kl *KubeLego) processProvider(ings []kubelego.Ingress) (err error) {
 		}
 
 		for _, ing := range ings {
-			if providerName == ing.IngressClass() {
-				err = provider.Process(ing)
-				if err != nil {
-					provider.Log().Error(err)
-				}
+			if ing.Ignore() {
+				kl.Log().Debug(fmt.Sprintf("Skipping ingress %q with class %q from provider %q", ing.Object().Name, ing.IngressClass(), providerName))
+				continue
+			}
+			kl.Log().Debug(fmt.Sprintf("Processing ingress %q from class %q with provider %q", ing.Object().Name, ing.IngressClass(), providerName))
+			err = provider.Process(ing)
+			if err != nil {
+				provider.Log().Error(err)
 			}
 		}
 


### PR DESCRIPTION
While trying to use kube-lego with an ingress class different than `nginx` and `gce`, I was not able to retrieve certificates from Let's Encrypt, even though the class was considered as supported.
Kube-Lego was simply skipping the ingress resources due [to the ingress class name not matching the kube-lego provider name](https://github.com/jetstack/kube-lego/blob/0.1.4/pkg/kubelego/configure.go#L66).

To fix that I replaced the provider and class name matching with the ingress class settings checks (`Ingress.Ignore()` method), ignoring only the ingress resources that do not match the supported class names and applying the valid resources to every registered provider.

I'm also submitting #194 that enables customizing the desired providers, to avoid any weird cases that may appear by applying the same ingress resources on both providers.

Related to #189
