### PR TITLE
Seperate concept of provider and class

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ Please note:
 | `LEGO_SERVICE_NAME_NGINX` | n | `kube-lego-nginx` | Service name for NGINX ingress |
 | `LEGO_SERVICE_NAME_GCE` | n | `kube-lego-gce` | Service name for GCE ingress |
 | `LEGO_SUPPORTED_INGRESS_CLASS` | n | `nginx,gce` | Specify the supported ingress class |
+| `LEGO_SUPPORTED_INGRESS_PROVIDER` | n | `nginx,gce` | Specify the supported ingress provider |
 | `LEGO_INGRESS_NAME_NGINX` | n | `kube-lego-nginx` | Ingress name which contains the routing for HTTP verification for nginx ingress |
 | `LEGO_PORT` | n | `8080` | Port where this daemon is listening for verifcation calls (HTTP method)|
 | `LEGO_CHECK_INTERVAL` | n | `8h` | Interval for periodically certificate checks (to find expired certs)|
 | `LEGO_MINIMUM_VALIDITY` | n | `720h` (30 days) | Request a renewal when the remaining certificate validity falls below that value|
 | `LEGO_DEFAULT_INGRESS_CLASS` | n | `nginx` | Default ingress class for resources without specification|
+| `LEGO_DEFAULT_INGRESS_PROVIDER` | n | `nginx` | Default ingress provider for resources without specification|
 | `LEGO_KUBE_API_URL` | n | `http://127.0.0.1:8080` | API server URL |
 | `LEGO_LOG_LEVEL` | n | `info` | Set log level (`debug`, `info`, `warn` or `error`) |
 | `LEGO_KUBE_ANNOTATION` | n | `kubernetes.io/tls-acme` | Set the ingress annotation used by this instance of kube-lego to get certificate for from Let's Encrypt. Allows you to run kube-lego against staging and production LE |

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -23,6 +23,16 @@ func IsSupportedIngressClass(supportedClass []string, in string) (out string, er
 	return "", fmt.Errorf("unsupported ingress class '%s'. Did you you forget to specify LEGO_DEFAULT_INGRESS_CLASS ?", in)
 }
 
+func IsSupportedIngressProvider(supportedProviders []string, in string) (out string, err error) {
+	out = strings.ToLower(in)
+	for _, supportedProvider := range supportedProviders {
+		if supportedProvider == out {
+			return out, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported ingress provider '%s'. Did you you forget to specify LEGO_DEFAULT_INGRESS_PROVIDER ?", in)
+}
+
 func IgnoreIngress(ing *k8sExtensions.Ingress) error {
 
 	key := kubelego.AnnotationEnabled
@@ -158,6 +168,14 @@ func (i *Ingress) IngressClass() string {
 	val, ok := i.IngressApi.Annotations[kubelego.AnnotationIngressClass]
 	if !ok {
 		return i.kubelego.LegoDefaultIngressClass()
+	}
+	return strings.ToLower(val)
+}
+
+func (i *Ingress) IngressProvider() string {
+	val, ok := i.IngressApi.Annotations[kubelego.AnnotationIngressProvider]
+	if !ok {
+		return i.kubelego.LegoDefaultIngressProvider()
 	}
 	return strings.ToLower(val)
 }

--- a/pkg/kubelego/configure.go
+++ b/pkg/kubelego/configure.go
@@ -63,7 +63,7 @@ func (kl *KubeLego) processProvider(ings []kubelego.Ingress) (err error) {
 		}
 
 		for _, ing := range ings {
-			if providerName == ing.IngressClass() {
+			if providerName == ing.IngressProvider() {
 				err = provider.Process(ing)
 				if err != nil {
 					provider.Log().Error(err)

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/jetstack/kube-lego/pkg/acme"
 	"github.com/jetstack/kube-lego/pkg/ingress"
-	"github.com/jetstack/kube-lego/pkg/kubelego_const"
 	"github.com/jetstack/kube-lego/pkg/provider/gce"
 	"github.com/jetstack/kube-lego/pkg/provider/nginx"
 	"github.com/jetstack/kube-lego/pkg/secret"
+	kubelego "github.com/movio/kube-lego/pkg/kubelego_const"
 
 	log "github.com/Sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -259,8 +259,8 @@ func (kl *KubeLego) paramsLego() error {
 		kl.legoServiceNameGce = "kube-lego-gce"
 	}
 
-	kl.legoSupportedIngressClass = strings.Split(os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS"),",")
-	if len(kl.legoSupportedIngressClass) == 1 {
+	kl.legoSupportedIngressClass = strings.Split(os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS"), ",")
+	if len(kl.legoSupportedIngressClass) == 0 {
 		kl.legoSupportedIngressClass = kubelego.SupportedIngressClasses
 	}
 

--- a/pkg/kubelego/type.go
+++ b/pkg/kubelego/type.go
@@ -15,27 +15,29 @@ import (
 )
 
 type KubeLego struct {
-	legoURL                   string
-	legoEmail                 string
-	legoSecretName            string
-	legoIngressNameNginx      string
-	legoNamespace             string
-	legoPodIP                 net.IP
-	legoServiceNameNginx      string
-	legoServiceNameGce        string
-	legoSupportedIngressClass []string
-	legoHTTPPort              intstr.IntOrString
-	legoCheckInterval         time.Duration
-	legoMinimumValidity       time.Duration
-	legoDefaultIngressClass   string
-	legoKubeApiURL            string
-	legoWatchNamespace        string
-	kubeClient                *kubernetes.Clientset
-	legoIngressSlice          []*ingress.Ingress
-	legoIngressProvider       map[string]kubelego.IngressProvider
-	log                       *log.Entry
-	version                   string
-	acmeClient                kubelego.Acme
+	legoURL                      string
+	legoEmail                    string
+	legoSecretName               string
+	legoIngressNameNginx         string
+	legoNamespace                string
+	legoPodIP                    net.IP
+	legoServiceNameNginx         string
+	legoServiceNameGce           string
+	legoSupportedIngressClass    []string
+	legoSupportedIngressProvider []string
+	legoHTTPPort                 intstr.IntOrString
+	legoCheckInterval            time.Duration
+	legoMinimumValidity          time.Duration
+	legoDefaultIngressClass      string
+	legoDefaultIngressProvider   string
+	legoKubeApiURL               string
+	legoWatchNamespace           string
+	kubeClient                   *kubernetes.Clientset
+	legoIngressSlice             []*ingress.Ingress
+	legoIngressProvider          map[string]kubelego.IngressProvider
+	log                          *log.Entry
+	version                      string
+	acmeClient                   kubelego.Acme
 
 	// stop channel for services
 	stopCh chan struct{}

--- a/pkg/kubelego_const/consts.go
+++ b/pkg/kubelego_const/consts.go
@@ -18,8 +18,10 @@ const TLSCaKey = "ca.crt"
 const AnnotationIngressChallengeEndpoints = "kubernetes.io/tls-acme-challenge-endpoints"
 const AnnotationIngressChallengeEndpointsHash = "kubernetes.io/tls-acme-challenge-endpoints-hash"
 const AnnotationIngressClass = "kubernetes.io/ingress.class"
+const AnnotationIngressProvider = "kubernetes.io/ingress.provider"
 const AnnotationSslRedirect = "ingress.kubernetes.io/ssl-redirect"
 const AnnotationKubeLegoManaged = "kubernetes.io/kube-lego-managed"
 
 var SupportedIngressClasses = []string{"nginx", "gce"}
+var SupportedIngressProviders = []string{"nginx", "gce"}
 var AnnotationEnabled = "kubernetes.io/tls-acme"

--- a/pkg/kubelego_const/interfaces.go
+++ b/pkg/kubelego_const/interfaces.go
@@ -24,7 +24,9 @@ type KubeLego interface {
 	LegoServiceNameNginx() string
 	LegoServiceNameGce() string
 	LegoDefaultIngressClass() string
+	LegoDefaultIngressProvider() string
 	LegoSupportedIngressClass() []string
+	LegoSupportedIngressProvider() []string
 	LegoCheckInterval() time.Duration
 	LegoMinimumValidity() time.Duration
 	LegoPodIP() net.IP
@@ -70,6 +72,7 @@ type Ingress interface {
 	Save() error
 	Delete() error
 	IngressClass() string
+	IngressProvider() string
 	Tls() []Tls
 	Ignore() bool
 }

--- a/pkg/mocks/kubelego.go
+++ b/pkg/mocks/kubelego.go
@@ -24,6 +24,7 @@ func DummyKubeLego(c *gomock.Controller) *MockKubeLego {
 	kl.EXPECT().LegoServiceNameNginx().AnyTimes().Return("kube-lego-nginx")
 	kl.EXPECT().LegoServiceNameGce().AnyTimes().Return("kube-lego-gce")
 	kl.EXPECT().LegoDefaultIngressClass().AnyTimes().Return("nginx")
+	kl.EXPECT().LegoDefaultIngressProvider().AnyTimes().Return("nginx")
 	kl.EXPECT().Log().AnyTimes().Return(log)
 	kl.EXPECT().Version().AnyTimes().Return("mocked-version")
 	kl.EXPECT().AcmeUser().AnyTimes().Return(nil, errors.New("I am only mocked"))

--- a/pkg/mocks/mocks.go
+++ b/pkg/mocks/mocks.go
@@ -4,6 +4,9 @@
 package mocks
 
 import (
+	net "net"
+	time "time"
+
 	logrus "github.com/Sirupsen/logrus"
 	gomock "github.com/golang/mock/gomock"
 	. "github.com/jetstack/kube-lego/pkg/kubelego_const"
@@ -11,8 +14,6 @@ import (
 	kubernetes "k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	net "net"
-	time "time"
 )
 
 // Mock of KubeLego interface
@@ -156,6 +157,16 @@ func (_mr *_MockKubeLegoRecorder) LegoDefaultIngressClass() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoDefaultIngressClass")
 }
 
+func (_m *MockKubeLego) LegoDefaultIngressProvider() string {
+	ret := _m.ctrl.Call(_m, "LegoDefaultIngressProvider")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockKubeLegoRecorder) LegoDefaultIngressProvider() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoDefaultIngressProvider")
+}
+
 func (_m *MockKubeLego) LegoSupportedIngressClass() []string {
 	ret := _m.ctrl.Call(_m, "LegoSupportedIngressClass")
 	ret0, _ := ret[0].([]string)
@@ -164,6 +175,16 @@ func (_m *MockKubeLego) LegoSupportedIngressClass() []string {
 
 func (_mr *_MockKubeLegoRecorder) LegoSupportedIngressClass() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoSupportedIngressClass")
+}
+
+func (_m *MockKubeLego) LegoSupportedIngressProvider() []string {
+	ret := _m.ctrl.Call(_m, "LegoSupportedIngressProvider")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+func (_mr *_MockKubeLegoRecorder) LegoSupportedIngressProvider() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoSupportedIngressProvider")
 }
 
 func (_m *MockKubeLego) LegoCheckInterval() time.Duration {
@@ -572,6 +593,16 @@ func (_m *MockIngress) IngressClass() string {
 
 func (_mr *_MockIngressRecorder) IngressClass() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IngressClass")
+}
+
+func (_m *MockIngress) IngressProvider() string {
+	ret := _m.ctrl.Call(_m, "IngressProvider")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockIngressRecorder) IngressProvider() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IngressProvider")
 }
 
 func (_m *MockIngress) Tls() []Tls {

--- a/pkg/provider/nginx/nginx.go
+++ b/pkg/provider/nginx/nginx.go
@@ -5,9 +5,10 @@ import (
 	"github.com/jetstack/kube-lego/pkg/kubelego_const"
 	"github.com/jetstack/kube-lego/pkg/service"
 
+	"sort"
+
 	"github.com/Sirupsen/logrus"
 	k8sExtensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"sort"
 )
 
 var _ kubelego.IngressProvider = &Nginx{}
@@ -120,6 +121,7 @@ func (p *Nginx) updateIngress() error {
 		kubelego.AnnotationIngressChallengeEndpoints: "true",
 		kubelego.AnnotationSslRedirect:               "false",
 		kubelego.AnnotationIngressClass:              p.kubelego.LegoDefaultIngressClass(),
+		kubelego.AnnotationIngressProvider:           p.kubelego.LegoDefaultIngressProvider(),
 	}
 
 	ing.Spec = k8sExtensions.IngressSpec{


### PR DESCRIPTION
Previously you're ingress provider and classes had to have the same name. These should be two different concepts and be used in combination.

For example if you have:

Ingress classes for nginx-internal and nginx-external but want them to both be provided by nginx then if you don't have the provider and class as two different concepts this isn't possible.

Below is an example ingress resource with the new annotation:

```apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: svc-ing
  namespace: some-namespace
  annotations:
    kubernetes.io/tls-acme: "true"
    kubernetes.io/ingress.provider: "nginx"
    kubernetes.io/ingress.class: "nginx-external"
    ingress.kubernetes.io/ssl-redirect: "true"
spec:
  tls:
  - hosts:
    - example.com
    secretName: svc-tls
  rules:
  - host: example.com
    http:
      paths:
      -
        path: /something
        backend:
          serviceName: svc
          servicePort: 80
```