### PR TITLE
Adjusted exponential backoff to avoid being blocked with ratelimiting…

### DIFF
--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -143,7 +143,10 @@ func (a *Acme) ObtainCertificate(domains []string) (data map[string][]byte, err 
 			}
 
 			b := backoff.NewExponentialBackOff()
-			b.MaxElapsedTime = time.Duration(time.Second * 60)
+			// At least for nginx, takes some time for the new
+			// ingress rule to kick in
+			b.InitialInterval = time.Duration(time.Second * 15)
+			b.MaxElapsedTime = time.Duration(time.Minute * 5)
 
 			err = backoff.Retry(op, b)
 			if err != nil {


### PR DESCRIPTION
… when using nginx ingress

From the slack channel:

jdrowell [4:12 AM]
Hi ppl, I'm setting up lego with nginx ingress. It works, but I always get 5 failures before the challenge passes, and unfortunately (for me) letsencrypt is rate limiting (since april) to what I understand is 5 cert requests per same host per account inside a 7 day windows. end result is I get rate limited every time on the prod server. On the staging server it ends up working but I still see the 5 failures in the logs (running with debug logs). The failure is the following:

[4:13] 
time="2017-06-11T07:07:02Z" level=debug msg="error while authorizing: waiting for authorization failed: acme: identifier authorization failed" context=acme domain=<DOMAIN>

[4:14] 
the reachability test passes (_selftest). There's a burst of 5 requests in 10 seconds, I get the hits from Let's Encrypt validation server, responses are 200, but it only works on the 6th attempt

jdrowell [4:26 AM] 
Uhmm I think I see what's happening here, it seems that the first requests from Let's Encrypt are hitting the default backend, because nginx didn't have time to reload the config yet. So in my case it returns an echo of the headers instead of the challenge response. Adding a 20s delay after detecting the new tls ingress should do the trick.

-- x --

Docs for ExponentialBackOff show that the first 5 requests (which cause the ratelimiting) will happen in under 3 seconds with default options. This is way faster than the nginx ingress controller hands over the /.well_known path to kube-lego.

I created a new docker image and pushed this to production, tested with both staging and prod Let's Encrypt services and it works well. The initial request still always fails, which is not good, but if someday the handoff becomes instant this will Just Work too. I usually get the cert on the 2nd or 3rd request.