### PR TITLE
correct wording when failing to get ingress

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -59,7 +59,7 @@ func New(client kubelego.KubeLego, namespace string, name string) *Ingress {
 			ingress.exists = false
 
 		} else {
-			client.Log().Warn("Error while getting secret: ", err)
+			client.Log().Warn("Error while getting ingress: ", err)
 		}
 	}
 


### PR DESCRIPTION
This error message currently reports that there was an error while
getting "secret", but it should actually state that it failed to
get an "ingress."