### PR TITLE
Add ability to log in json

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Please note:
 | `LEGO_DEFAULT_INGRESS_CLASS` | n | `nginx` | Default ingress class for resources without specification|
 | `LEGO_KUBE_API_URL` | n | `http://127.0.0.1:8080` | API server URL |
 | `LEGO_LOG_LEVEL` | n | `info` | Set log level (`debug`, `info`, `warn` or `error`) |
+| `LEGO_LOG_TYPE` | n | `text` | Set log type. Only `json` as custom value supported, everything else defaults to default logrus textFormat |
 | `LEGO_KUBE_ANNOTATION` | n | `kubernetes.io/tls-acme` | Set the ingress annotation used by this instance of kube-lego to get certificate for from Let's Encrypt. Allows you to run kube-lego against staging and production LE |
 | `LEGO_WATCH_NAMESPACE` | n | `` | Namespace that kube-lego should watch for ingresses and services |
 

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -28,6 +28,20 @@ import (
 var _ kubelego.KubeLego = &KubeLego{}
 
 func makeLog() *log.Entry {
+	logtype := strings.ToLower(os.Getenv("LEGO_LOG_TYPE"))
+	if logtype == "" {
+		logtype = "text"
+	}
+
+	if logtype == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	} else if logtype == "text" {
+		log.SetFormatter(&log.TextFormatter{})
+	} else {
+		log.WithField("logtype", logtype).Fatal("Given logtype was not valid, check LEGO_LOG_TYPE configuration")
+		os.Exit(1)
+	}
+
 	loglevel := strings.ToLower(os.Getenv("LEGO_LOG_LEVEL"))
 	if len(loglevel) == 0 {
 		log.SetLevel(log.InfoLevel)


### PR DESCRIPTION
Adds ability to change logformat in logrus.`json` is super useful for people using eg. Splunk or Logstash.

Configuration stanza is the default from https://github.com/sirupsen/logrus/blob/3d4380f53a34dcdc95f0c1db702615992b38d9a4/README.md#L22

Default to `text` if no other value is given, but error and exit on non-supported values.