### PR TITLE
Added a sanity check before submitting CSR

### DIFF
--- a/pkg/ingress/tls.go
+++ b/pkg/ingress/tls.go
@@ -113,7 +113,7 @@ func (i *Tls) Process() error {
 func (i *Tls) RequestCert() error {
 	// sanity check
 	if i.IngressTLS.SecretName == "" {
-		return errors.New("ingress has an empty SecretName. Must fail")
+		return errors.New("Ingress has an empty secretName. Skipping certificate retrieval")
 	}
 
 	i.Log().Infof("requesting certificate for %s", strings.Join(i.Hosts(), ","))

--- a/pkg/ingress/tls.go
+++ b/pkg/ingress/tls.go
@@ -1,17 +1,18 @@
 package ingress
 
 import (
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jetstack/kube-lego/pkg/kubelego_const"
 	"github.com/jetstack/kube-lego/pkg/secret"
 	"github.com/jetstack/kube-lego/pkg/utils"
 
-	"fmt"
 	"github.com/Sirupsen/logrus"
 	k8sApi "k8s.io/client-go/pkg/api/v1"
 	k8sExtensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"strings"
 )
 
 var _ kubelego.Tls = &Tls{}
@@ -110,6 +111,10 @@ func (i *Tls) Process() error {
 }
 
 func (i *Tls) RequestCert() error {
+	// sanity check
+	if i.IngressTLS.SecretName == "" {
+		return errors.New("ingress has an empty SecretName. Must fail")
+	}
 
 	i.Log().Infof("requesting certificate for %s", strings.Join(i.Hosts(), ","))
 


### PR DESCRIPTION
This PR adds a sanity check for `k8sExtensions.IngressTLS` resource. If the resource is malformed, no attempt to request a certificate would be made.

Here's an example of bad tls:

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: test
  annotations:
    kubernetes.io/tls-acme: "true"
spec:
  tls:
  - hosts:
    - test.example
  - secretName: test-tls
  rules:
  - host: test.example
    http:
      paths:
      - path: /
        backend:
          serviceName: test
          servicePort: 80
```

Notice that `secretName` has a typo in front of it.

Such a yaml would be gladly accepted by k8s (which is a k8s problem, surely), but kube-lego makes it worse by first requesting and obtaining a certificate and then failing to store it anywhere.