### PR TITLE
Return ingress.class value for ingress.provider if not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ Please note:
 | `LEGO_CHECK_INTERVAL` | n | `8h` | Interval for periodically certificate checks (to find expired certs)|
 | `LEGO_MINIMUM_VALIDITY` | n | `720h` (30 days) | Request a renewal when the remaining certificate validity falls below that value|
 | `LEGO_DEFAULT_INGRESS_CLASS` | n | `nginx` | Default ingress class for resources without specification|
-| `LEGO_DEFAULT_INGRESS_PROVIDER` | n | `nginx` | Default ingress provider for resources without specification|
 | `LEGO_KUBE_API_URL` | n | `http://127.0.0.1:8080` | API server URL |
 | `LEGO_LOG_LEVEL` | n | `info` | Set log level (`debug`, `info`, `warn` or `error`) |
 | `LEGO_LOG_TYPE` | n | `text` | Set log type. Only `json` as custom value supported, everything else defaults to default logrus textFormat |

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -175,7 +175,9 @@ func (i *Ingress) IngressClass() string {
 func (i *Ingress) IngressProvider() string {
 	val, ok := i.IngressApi.Annotations[kubelego.AnnotationIngressProvider]
 	if !ok {
-		return i.kubelego.LegoDefaultIngressProvider()
+		// we return IngressClass() here in order to not break backwards
+		// compatibility with older versions of kube-lego
+		return i.IngressClass()
 	}
 	return strings.ToLower(val)
 }

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -196,10 +196,6 @@ func (kl *KubeLego) LegoDefaultIngressClass() string {
 	return kl.legoDefaultIngressClass
 }
 
-func (kl *KubeLego) LegoDefaultIngressProvider() string {
-	return kl.legoDefaultIngressProvider
-}
-
 func (kl *KubeLego) LegoIngressNameNginx() string {
 	return kl.legoIngressNameNginx
 }
@@ -295,17 +291,6 @@ func (kl *KubeLego) paramsLego() error {
 		kl.legoSupportedIngressProvider = kubelego.SupportedIngressProviders
 	} else {
 		kl.legoSupportedIngressProvider = strings.Split(supportedProviders, ",")
-	}
-
-	legoDefaultIngressProvider := os.Getenv("LEGO_DEFAULT_INGRESS_PROVIDER")
-	if len(legoDefaultIngressProvider) == 0 {
-		kl.legoDefaultIngressProvider = "nginx"
-	} else {
-		var err error = nil
-		kl.legoDefaultIngressProvider, err = ingress.IsSupportedIngressProvider(kl.legoSupportedIngressProvider, legoDefaultIngressProvider)
-		if err != nil {
-			return fmt.Errorf("Unsupported default ingress provider: '%s'. You can set the ingress provider with 'LEGO_DEFAULT_INGRESS_PROVIDER'", legoDefaultIngressProvider)
-		}
 	}
 
 	kl.legoSupportedIngressClass = strings.Split(os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS"), ",")

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -293,9 +293,11 @@ func (kl *KubeLego) paramsLego() error {
 		kl.legoSupportedIngressProvider = strings.Split(supportedProviders, ",")
 	}
 
-	kl.legoSupportedIngressClass = strings.Split(os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS"), ",")
-	if len(kl.legoSupportedIngressClass) == 0 {
+	legoSupportedIngressClass := os.Getenv("LEGO_SUPPORTED_INGRESS_CLASS")
+	if len(legoSupportedIngressClass) == 0 {
 		kl.legoSupportedIngressClass = kubelego.SupportedIngressClasses
+	} else {
+		kl.legoSupportedIngressClass = strings.Split(legoSupportedIngressClass, ",")
 	}
 
 	legoDefaultIngressClass := os.Getenv("LEGO_DEFAULT_INGRESS_CLASS")

--- a/pkg/kubelego_const/interfaces.go
+++ b/pkg/kubelego_const/interfaces.go
@@ -24,7 +24,6 @@ type KubeLego interface {
 	LegoServiceNameNginx() string
 	LegoServiceNameGce() string
 	LegoDefaultIngressClass() string
-	LegoDefaultIngressProvider() string
 	LegoSupportedIngressClass() []string
 	LegoSupportedIngressProvider() []string
 	LegoCheckInterval() time.Duration

--- a/pkg/provider/nginx/nginx.go
+++ b/pkg/provider/nginx/nginx.go
@@ -120,9 +120,11 @@ func (p *Nginx) updateIngress() error {
 	ing.Annotations = map[string]string{
 		kubelego.AnnotationIngressChallengeEndpoints: "true",
 		kubelego.AnnotationSslRedirect:               "false",
-		kubelego.AnnotationIngressClass:              p.kubelego.LegoDefaultIngressClass(),
-		kubelego.AnnotationIngressProvider:           p.kubelego.LegoDefaultIngressProvider(),
-		kubelego.AnnotationWhitelistSourceRange:      "0.0.0.0/0",
+		// TODO: use the ingres class as specified on the ingress we are
+		// requesting a certificate for
+		kubelego.AnnotationIngressClass:         p.kubelego.LegoDefaultIngressClass(),
+		kubelego.AnnotationIngressProvider:      "nginx",
+		kubelego.AnnotationWhitelistSourceRange: "0.0.0.0/0",
 	}
 
 	ing.Spec = k8sExtensions.IngressSpec{


### PR DESCRIPTION
This should solve a regression that causes the GCE ingress controller implementation to not work with manifests that don't explicitly set `kubernetes.io/ingress.provider: gce`. Without this change, these manifests would attempt to use the `nginx` provider.

This also solves a problem where the default supported ingress classes were not set correctly if not specified.