### PR TITLE
delete leftover from legoDefaultIngressProvider removal

### DIFF
--- a/pkg/kubelego/type.go
+++ b/pkg/kubelego/type.go
@@ -29,7 +29,6 @@ type KubeLego struct {
 	legoCheckInterval            time.Duration
 	legoMinimumValidity          time.Duration
 	legoDefaultIngressClass      string
-	legoDefaultIngressProvider   string
 	legoKubeApiURL               string
 	legoWatchNamespace           string
 	kubeClient                   *kubernetes.Clientset

--- a/pkg/mocks/kubelego.go
+++ b/pkg/mocks/kubelego.go
@@ -24,7 +24,6 @@ func DummyKubeLego(c *gomock.Controller) *MockKubeLego {
 	kl.EXPECT().LegoServiceNameNginx().AnyTimes().Return("kube-lego-nginx")
 	kl.EXPECT().LegoServiceNameGce().AnyTimes().Return("kube-lego-gce")
 	kl.EXPECT().LegoDefaultIngressClass().AnyTimes().Return("nginx")
-	kl.EXPECT().LegoDefaultIngressProvider().AnyTimes().Return("nginx")
 	kl.EXPECT().Log().AnyTimes().Return(log)
 	kl.EXPECT().Version().AnyTimes().Return("mocked-version")
 	kl.EXPECT().AcmeUser().AnyTimes().Return(nil, errors.New("I am only mocked"))

--- a/pkg/mocks/mocks.go
+++ b/pkg/mocks/mocks.go
@@ -4,9 +4,6 @@
 package mocks
 
 import (
-	net "net"
-	time "time"
-
 	logrus "github.com/Sirupsen/logrus"
 	gomock "github.com/golang/mock/gomock"
 	. "github.com/jetstack/kube-lego/pkg/kubelego_const"
@@ -14,6 +11,8 @@ import (
 	kubernetes "k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	net "net"
+	time "time"
 )
 
 // Mock of KubeLego interface
@@ -155,16 +154,6 @@ func (_m *MockKubeLego) LegoDefaultIngressClass() string {
 
 func (_mr *_MockKubeLegoRecorder) LegoDefaultIngressClass() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoDefaultIngressClass")
-}
-
-func (_m *MockKubeLego) LegoDefaultIngressProvider() string {
-	ret := _m.ctrl.Call(_m, "LegoDefaultIngressProvider")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-func (_mr *_MockKubeLegoRecorder) LegoDefaultIngressProvider() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoDefaultIngressProvider")
 }
 
 func (_m *MockKubeLego) LegoSupportedIngressClass() []string {


### PR DESCRIPTION
https://github.com/jetstack/kube-lego/commit/a4d76c22976301016cdbf1d16d7376520fa9896b deleted support for `legoDefaultIngressProvider` but did not clean up all the related code. The PR removes the leftover. pkg/mocks/mocks.go was modified using `make codegen`.