### PR TITLE
Memoize secret obj

### DIFF
--- a/pkg/ingress/tls.go
+++ b/pkg/ingress/tls.go
@@ -52,7 +52,8 @@ func (t *Tls) Secret() kubelego.Secret {
 		return t.secret
 	}
 	meta := t.SecretMetadata()
-	return secret.New(t.ingress.KubeLego(), meta.Namespace, meta.Name)
+	t.secret = secret.New(t.ingress.KubeLego(), meta.Namespace, meta.Name)
+	return t.secret
 }
 
 func (t *Tls) Hosts() []string {

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -31,7 +31,7 @@ func New(client kubelego.KubeLego, namespace string, name string) *Secret {
 					Name:      name,
 				},
 			}
-			secret.Log().Info("Attempting to create new secret")
+			secret.Log().Debug("Initialized a new secret")
 			secret.exists = false
 		} else {
 			client.Log().Warn("Error while getting secret: ", err)


### PR DESCRIPTION
`(i *Tls) Process()` function makes an extra `client.KubeClient().Secrets(namespace).Get(name, k8sMeta.GetOptions{})` call when a certificate needed for a given `Tls` object. The first call happens in `i.newCertNeeded` and the second call happens in `i.RequestCert`. There's already an effort for memoization of secret object, but it is buggy(I'm assuming that was not intentional - correct me if I'm wrong), i.e it does not set the initialized secret object to `t.secret` variable. The PR fixes the issue and adds test coverage.