### PR TITLE
Whitelist IPv6 default route

### DIFF
--- a/pkg/provider/nginx/nginx.go
+++ b/pkg/provider/nginx/nginx.go
@@ -124,7 +124,7 @@ func (p *Nginx) updateIngress() error {
 		// requesting a certificate for
 		kubelego.AnnotationIngressClass:         p.kubelego.LegoDefaultIngressClass(),
 		kubelego.AnnotationIngressProvider:      "nginx",
-		kubelego.AnnotationWhitelistSourceRange: "0.0.0.0/0",
+		kubelego.AnnotationWhitelistSourceRange: "0.0.0.0/0,::/0",
 	}
 
 	ing.Spec = k8sExtensions.IngressSpec{


### PR DESCRIPTION
Without this PR the http-01 challenge (``/.well-known/acme-challenge``) fails in a setup where one has IPv6 (AAAA DNS record) set.

## IPv4 probe succeeds

```
$ HOST=mysite.com; IP=212.123.123.123; curl -4 -L -I --resolve ${HOST}:80:${IP} --resolve ${HOST}:443:${IP} http://${HOST}/.well-known/acme-challenge/_selftest
HTTP/1.1 200 OK
Server: nginx
Date: Sun, 03 Sep 2017 09:18:35 GMT
Content-Type: text/plain
Content-Length: 16
Strict-Transport-Security: max-age=15724800; includeSubDomains;
```

## IPv6 probe fails

```
$ HOST=mysite.com; IP=2001:41e0:123:123::123; curl -6 -L -I --resolve ${HOST}:80:${IP} --resolve ${HOST}:443:${IP} http://${HOST}/.well-known/acme-challenge/_selftest
HTTP/1.1 403 Forbidden
Server: nginx
Date: Sun, 03 Sep 2017 09:18:39 GMT
Content-Type: text/html
Content-Length: 162
Strict-Transport-Security: max-age=15724800; includeSubDomains;
```

Introduced by https://github.com/jetstack/kube-lego/pull/114
Potentially relates to https://github.com/jetstack/kube-lego/issues/66