### PR TITLE
Reintroduce default ingress provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Please note:
 | `LEGO_SUPPORTED_INGRESS_CLASS` | n | `nginx,gce` | Specify the supported ingress class |
 | `LEGO_SUPPORTED_INGRESS_PROVIDER` | n | `nginx,gce` | Specify the supported ingress provider |
 | `LEGO_INGRESS_NAME_NGINX` | n | `kube-lego-nginx` | Ingress name which contains the routing for HTTP verification for nginx ingress |
-| `LEGO_PORT` | n | `8080` | Port where this daemon is listening for verifcation calls (HTTP method)|
-| `LEGO_CHECK_INTERVAL` | n | `8h` | Interval for periodically certificate checks (to find expired certs)|
-| `LEGO_MINIMUM_VALIDITY` | n | `720h` (30 days) | Request a renewal when the remaining certificate validity falls below that value|
+| `LEGO_PORT` | n | `8080` | Port where this daemon is listening for verifcation calls (HTTP method) |
+| `LEGO_CHECK_INTERVAL` | n | `8h` | Interval for periodically certificate checks (to find expired certs) |
+| `LEGO_MINIMUM_VALIDITY` | n | `720h` (30 days) | Request a renewal when the remaining certificate validity falls below that value |
 | `LEGO_DEFAULT_INGRESS_CLASS` | n | `nginx` | Default ingress class for resources without specification|
-| `LEGO_DEFAULT_INGRESS_PROVIDER` | n | `$LEGO_DEFAULT_INGRESS_CLASS` | Default ingress provider for resources without specification|
+| `LEGO_DEFAULT_INGRESS_PROVIDER` | n | `$LEGO_DEFAULT_INGRESS_CLASS` | Default ingress provider for resources without specification |
 | `LEGO_KUBE_API_URL` | n | `http://127.0.0.1:8080` | API server URL |
 | `LEGO_LOG_LEVEL` | n | `info` | Set log level (`debug`, `info`, `warn` or `error`) |
 | `LEGO_LOG_TYPE` | n | `text` | Set log type. Only `json` as custom value supported, everything else defaults to default logrus textFormat |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Please note:
 | `LEGO_CHECK_INTERVAL` | n | `8h` | Interval for periodically certificate checks (to find expired certs)|
 | `LEGO_MINIMUM_VALIDITY` | n | `720h` (30 days) | Request a renewal when the remaining certificate validity falls below that value|
 | `LEGO_DEFAULT_INGRESS_CLASS` | n | `nginx` | Default ingress class for resources without specification|
+| `LEGO_DEFAULT_INGRESS_PROVIDER` | n | `$LEGO_DEFAULT_INGRESS_CLASS` | Default ingress provider for resources without specification|
 | `LEGO_KUBE_API_URL` | n | `http://127.0.0.1:8080` | API server URL |
 | `LEGO_LOG_LEVEL` | n | `info` | Set log level (`debug`, `info`, `warn` or `error`) |
 | `LEGO_LOG_TYPE` | n | `text` | Set log type. Only `json` as custom value supported, everything else defaults to default logrus textFormat |

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jetstack/kube-lego/pkg/kubelego_const"
+	kubelego "github.com/jetstack/kube-lego/pkg/kubelego_const"
 
 	"github.com/Sirupsen/logrus"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -175,9 +175,7 @@ func (i *Ingress) IngressClass() string {
 func (i *Ingress) IngressProvider() string {
 	val, ok := i.IngressApi.Annotations[kubelego.AnnotationIngressProvider]
 	if !ok {
-		// we return IngressClass() here in order to not break backwards
-		// compatibility with older versions of kube-lego
-		return i.IngressClass()
+		return i.kubelego.LegoDefaultIngressProvider()
 	}
 	return strings.ToLower(val)
 }

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -196,6 +196,10 @@ func (kl *KubeLego) LegoDefaultIngressClass() string {
 	return kl.legoDefaultIngressClass
 }
 
+func (kl *KubeLego) LegoDefaultIngressProvider() string {
+	return kl.legoDefaultIngressProvider
+}
+
 func (kl *KubeLego) LegoIngressNameNginx() string {
 	return kl.legoIngressNameNginx
 }
@@ -310,6 +314,22 @@ func (kl *KubeLego) paramsLego() error {
 			return fmt.Errorf("Unsupported default ingress class: '%s'. You can set the ingress class with 'LEGO_DEFAULT_INGRESS_CLASS'", legoDefaultIngressClass)
 		}
 	}
+
+	legoDefaultIngressProvider := os.Getenv("LEGO_DEFAULT_INGRESS_PROVIDER")
+	if len(legoDefaultIngressProvider) == 0 {
+		/*
+			To support backwards compatability we need to set the default provier
+			to the same as the default class
+		*/
+		kl.legoDefaultIngressProvider = kl.legoDefaultIngressClass
+	} else {
+		var err error = nil
+		kl.legoDefaultIngressProvider, err = ingress.IsSupportedIngressProvider(kl.legoSupportedIngressProvider, legoDefaultIngressProvider)
+		if err != nil {
+			return fmt.Errorf("Unsupported default ingress provider: '%s'. You can set the ingress provider with 'LEGO_DEFAULT_INGRESS_PROVIDER'", legoDefaultIngressProvider)
+		}
+	}
+
 	kl.legoIngressNameNginx = os.Getenv("LEGO_INGRESS_NAME_NGINX")
 	if len(kl.legoIngressNameNginx) == 0 {
 		kl.legoIngressNameNginx = os.Getenv("LEGO_INGRESS_NAME")

--- a/pkg/kubelego_const/interfaces.go
+++ b/pkg/kubelego_const/interfaces.go
@@ -24,6 +24,7 @@ type KubeLego interface {
 	LegoServiceNameNginx() string
 	LegoServiceNameGce() string
 	LegoDefaultIngressClass() string
+	LegoDefaultIngressProvider() string
 	LegoSupportedIngressClass() []string
 	LegoSupportedIngressProvider() []string
 	LegoCheckInterval() time.Duration

--- a/pkg/provider/nginx/nginx.go
+++ b/pkg/provider/nginx/nginx.go
@@ -2,7 +2,7 @@ package nginx
 
 import (
 	"github.com/jetstack/kube-lego/pkg/ingress"
-	"github.com/jetstack/kube-lego/pkg/kubelego_const"
+	kubelego "github.com/jetstack/kube-lego/pkg/kubelego_const"
 	"github.com/jetstack/kube-lego/pkg/service"
 
 	"sort"
@@ -123,7 +123,7 @@ func (p *Nginx) updateIngress() error {
 		// TODO: use the ingres class as specified on the ingress we are
 		// requesting a certificate for
 		kubelego.AnnotationIngressClass:         p.kubelego.LegoDefaultIngressClass(),
-		kubelego.AnnotationIngressProvider:      "nginx",
+		kubelego.AnnotationIngressProvider:      p.kubelego.LegoDefaultIngressProvider(),
 		kubelego.AnnotationWhitelistSourceRange: "0.0.0.0/0,::/0",
 	}
 


### PR DESCRIPTION
This implementation should be backwards compatible as
it will default the provider to the same value as the class.

Relates to #233 