### PR TITLE
update only service with kube-lego-managed annotation

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -82,12 +82,15 @@ func (s *Service) Save() error {
 	if s.exists {
 		annotationVal, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
 		if !ok || annotationVal != "true" {
-			return fmt.Errorf(
-				"do not update service '%s/%s' as it does not have %s=true annotation",
-				s.ServiceApi.Namespace,
-				s.ServiceApi.Name,
-				kubelego.AnnotationKubeLegoManaged,
+			s.Log(
+				fmt.Errorf(
+					"not updating service '%s/%s' as it does not have %s=true annotation",
+					s.ServiceApi.Namespace,
+					s.ServiceApi.Name,
+					kubelego.AnnotationKubeLegoManaged,
+				)
 			)
+			return nil
 		}
 		obj, err = s.client().Update(s.ServiceApi)
 	} else {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -82,13 +82,11 @@ func (s *Service) Save() error {
 	if s.exists {
 		annotationVal, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
 		if !ok || annotationVal != "true" {
-			s.kubelego.Log().Info(
-				fmt.Errorf(
-					"Not updating service '%s/%s' as it does not have %s=true annotation",
-					s.ServiceApi.Namespace,
-					s.ServiceApi.Name,
-					kubelego.AnnotationKubeLegoManaged,
-				)
+			s.kubelego.Log().Infof(
+				"Not updating service '%s/%s' as it does not have %s=true annotation",
+				s.ServiceApi.Namespace,
+				s.ServiceApi.Name,
+				kubelego.AnnotationKubeLegoManaged
 			)
 			return nil
 		}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -58,7 +58,7 @@ func (s *Service) Delete() error {
 	val, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
 	if !ok || val != "true" {
 		return fmt.Errorf(
-			"do not delete service '%s/%s' as it has not %s=true annotation",
+			"do not delete service '%s/%s' as it does not have %s=true annotation",
 			s.ServiceApi.Namespace,
 			s.ServiceApi.Name,
 			kubelego.AnnotationKubeLegoManaged,
@@ -83,7 +83,7 @@ func (s *Service) Save() error {
 		annotationVal, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
 		if !ok || annotationVal != "true" {
 			return fmt.Errorf(
-				"do not update service '%s/%s' as it has not %s=true annotation",
+				"do not update service '%s/%s' as it does not have %s=true annotation",
 				s.ServiceApi.Namespace,
 				s.ServiceApi.Name,
 				kubelego.AnnotationKubeLegoManaged,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -86,7 +86,7 @@ func (s *Service) Save() error {
 				"Not updating service '%s/%s' as it does not have %s=true annotation",
 				s.ServiceApi.Namespace,
 				s.ServiceApi.Name,
-				kubelego.AnnotationKubeLegoManaged
+				kubelego.AnnotationKubeLegoManaged,
 			)
 			return nil
 		}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -82,9 +82,9 @@ func (s *Service) Save() error {
 	if s.exists {
 		annotationVal, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
 		if !ok || annotationVal != "true" {
-			s.Log(
+			s.kubelego.Log().Info(
 				fmt.Errorf(
-					"not updating service '%s/%s' as it does not have %s=true annotation",
+					"Not updating service '%s/%s' as it does not have %s=true annotation",
 					s.ServiceApi.Namespace,
 					s.ServiceApi.Name,
 					kubelego.AnnotationKubeLegoManaged,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -58,7 +58,7 @@ func (s *Service) Delete() error {
 	val, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
 	if !ok || val != "true" {
 		return fmt.Errorf(
-			"do not delete service '%s/%s' as it has no %s annotation",
+			"do not delete service '%s/%s' as it has not %s=true annotation",
 			s.ServiceApi.Namespace,
 			s.ServiceApi.Name,
 			kubelego.AnnotationKubeLegoManaged,
@@ -80,6 +80,15 @@ func (s *Service) Save() error {
 	var err error
 
 	if s.exists {
+		annotationVal, ok := s.ServiceApi.Annotations[kubelego.AnnotationKubeLegoManaged]
+		if !ok || annotationVal != "true" {
+			return fmt.Errorf(
+				"do not update service '%s/%s' as it has not %s=true annotation",
+				s.ServiceApi.Namespace,
+				s.ServiceApi.Name,
+				kubelego.AnnotationKubeLegoManaged,
+			)
+		}
 		obj, err = s.client().Update(s.ServiceApi)
 	} else {
 		obj, err = s.client().Create(s.ServiceApi)


### PR DESCRIPTION
To workaround the issue with GCE here https://github.com/jetstack/kube-lego/issues/68 I want to setup manually service with selector and have kube-lego for each of my namespaces.

But kube-lego ignores the service annotation when it is updating the service. This adds check for kube-lego-managed=true annotation for updating existing service - similarly to the delete method already there.

