### PR TITLE
Remove trailing slash from Lego Url

### DIFF
--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -267,6 +267,9 @@ func (kl *KubeLego) paramsLego() error {
 	if len(kl.legoURL) == 0 {
 		kl.legoURL = "https://acme-staging.api.letsencrypt.org/directory"
 	}
+	if strings.HasSuffix(kl.legoURL, "/") {
+		kl.legoURL = kl.legoURL[:len(kl.legoURL)-1]
+	}
 
 	kl.legoSecretName = os.Getenv("LEGO_SECRET_NAME")
 	if len(kl.legoSecretName) == 0 {

--- a/pkg/kubelego/kubelego_test.go
+++ b/pkg/kubelego/kubelego_test.go
@@ -1,0 +1,31 @@
+package kubelego
+
+import (
+	"os"
+	"testing"
+)
+
+func TestKubeLego_LegoUrl(t *testing.T) {
+	kl := New("")
+	os.Setenv("LEGO_EMAIL", "test@example.com")
+	os.Setenv("LEGO_POD_IP", "10.0.0.1")
+
+	kl.paramsLego()
+	if len(kl.LegoURL()) == 0 {
+		t.Error("LegoUrl must not be empty when not set")
+	}
+
+	testurl := "http://example.com/acme"
+	os.Setenv("LEGO_URL", testurl)
+	kl.paramsLego()
+	if kl.legoURL != testurl {
+		t.Error("LegoUrl was not set correctly")
+	}
+
+	testurlWithTrailingSlash := testurl + "/"
+	os.Setenv("LEGO_URL", testurlWithTrailingSlash)
+	kl.paramsLego()
+	if kl.legoURL != testurl {
+		t.Error("Trailing slash was not removed from LegoUrl ")
+	}
+}


### PR DESCRIPTION
Hi,

with this change a potential trailing slash is removed from the Lego Url.
Fixes #219 

Regards, Marc