### PR TITLE
Make RSA key size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Please note:
 | `LEGO_LOG_TYPE` | n | `text` | Set log type. Only `json` as custom value supported, everything else defaults to default logrus textFormat |
 | `LEGO_KUBE_ANNOTATION` | n | `kubernetes.io/tls-acme` | Set the ingress annotation used by this instance of kube-lego to get certificate for from Let's Encrypt. Allows you to run kube-lego against staging and production LE |
 | `LEGO_WATCH_NAMESPACE` | n | `` | Namespace that kube-lego should watch for ingresses and services |
+| `LEGO_RSA_KEYSIZE` | n | `2048` | Size of the private RSA key |
 
 ## Full deployment examples
 

--- a/pkg/acme/acme_e2e_test.go
+++ b/pkg/acme/acme_e2e_test.go
@@ -30,6 +30,7 @@ func TestAcme_E2E(t *testing.T) {
 	mockKL.EXPECT().LegoURL().MinTimes(1).Return("https://acme-staging.api.letsencrypt.org/directory")
 	mockKL.EXPECT().LegoEmail().MinTimes(1).Return("kube-lego-e2e@example.com")
 	mockKL.EXPECT().SaveAcmeUser(gomock.Any()).MinTimes(1).Return(nil)
+	mockKL.EXPECT().LegoRsaKeySize().AnyTimes().Return(2048)
 
 	// set up ngrok
 	command := []string{"ngrok", "http", "--bind-tls", "false", "8181"}

--- a/pkg/acme/user.go
+++ b/pkg/acme/user.go
@@ -126,7 +126,7 @@ func (a *Acme) validateUser(client *acme.Client, accountURI string) (account *ac
 
 func (a *Acme) generatePrivateKey() ([]byte, *rsa.PrivateKey, error) {
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, kubelego.RsaKeySize)
+	privateKey, err := rsa.GenerateKey(rand.Reader, a.kubelego.LegoRsaKeySize())
 	if err != nil {
 		return []byte{}, nil, err
 	}

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -231,6 +231,10 @@ func (kl *KubeLego) LegoKubeApiURL() string {
 	return kl.legoKubeApiURL
 }
 
+func (kl *KubeLego) LegoRsaKeySize() int {
+	return kl.legoRsaKeySize
+}
+
 func (kl *KubeLego) acmeSecret() *secret.Secret {
 	return secret.New(kl, kl.LegoNamespace(), kl.legoSecretName)
 }
@@ -404,5 +408,19 @@ func (kl *KubeLego) paramsLego() error {
 	} else {
 		kl.legoWatchNamespace = watchNamespace
 	}
+
+	rsaKeySize := os.Getenv("LEGO_RSA_KEYSIZE")
+	if len(rsaKeySize) == 0 {
+		kl.legoRsaKeySize = kubelego.DefaultRsaKeySize
+	} else {
+		if rsaKeySizeNumeric, err := strconv.Atoi(rsaKeySize); err != nil {
+			return fmt.Errorf("Invalid 'RSA_KEYSIZE': '%s'. Must be a number.", rsaKeySize)
+		} else if rsaKeySizeNumeric < 512 {
+			return fmt.Errorf("Invalid 'RSA_KEYSIZE': '%s'. Must be at least 512.", rsaKeySize)
+		} else {
+			kl.legoRsaKeySize = rsaKeySizeNumeric
+		}
+	}
+
 	return nil
 }

--- a/pkg/kubelego/kubelego_test.go
+++ b/pkg/kubelego/kubelego_test.go
@@ -1,6 +1,7 @@
 package kubelego
 
 import (
+	"github.com/jetstack/kube-lego/pkg/kubelego_const"
 	"os"
 	"testing"
 )
@@ -28,4 +29,38 @@ func TestKubeLego_LegoUrl(t *testing.T) {
 	if kl.legoURL != testurl {
 		t.Error("Trailing slash was not removed from LegoUrl ")
 	}
+}
+
+func TestKubeLego_RsaKeySize(t *testing.T) {
+	kl := New("")
+	os.Setenv("LEGO_EMAIL", "test@example.com")
+	os.Setenv("LEGO_POD_IP", "10.0.0.1")
+
+	kl.paramsLego()
+	if kl.LegoRsaKeySize() != kubelego.DefaultRsaKeySize {
+		t.Error("LegoRsaKeySize default value not set")
+	}
+
+	os.Setenv("LEGO_RSA_KEYSIZE", "abc")
+	if err := kl.paramsLego(); err == nil {
+		t.Error("invalid LegoRsaKeySize was accepted")
+	}
+
+	os.Setenv("LEGO_RSA_KEYSIZE", "511")
+	if err := kl.paramsLego(); err == nil {
+		t.Error("invalid LegoRsaKeySize was accepted")
+	}
+
+	os.Setenv("LEGO_RSA_KEYSIZE", "512")
+	kl.paramsLego()
+	if kl.LegoRsaKeySize() != 512 {
+		t.Error("LegoRsaKeySize not set correctly")
+	}
+
+	os.Setenv("LEGO_RSA_KEYSIZE", "4096")
+	kl.paramsLego()
+	if kl.LegoRsaKeySize() != 4096 {
+		t.Error("LegoRsaKeySize not set correctly")
+	}
+
 }

--- a/pkg/kubelego/type.go
+++ b/pkg/kubelego/type.go
@@ -38,6 +38,7 @@ type KubeLego struct {
 	log                          *log.Entry
 	version                      string
 	acmeClient                   kubelego.Acme
+	legoRsaKeySize               int
 
 	// stop channel for services
 	stopCh chan struct{}

--- a/pkg/kubelego_const/consts.go
+++ b/pkg/kubelego_const/consts.go
@@ -4,7 +4,7 @@ import (
 	k8sApi "k8s.io/client-go/pkg/api/v1"
 )
 
-const RsaKeySize = 2048
+const DefaultRsaKeySize = 2048
 const AcmeRegistration = "acme-registration.json"
 const AcmeRegistrationUrl = "acme-registration-url"
 const AcmePrivateKey = k8sApi.TLSPrivateKeyKey

--- a/pkg/kubelego_const/interfaces.go
+++ b/pkg/kubelego_const/interfaces.go
@@ -30,6 +30,7 @@ type KubeLego interface {
 	LegoCheckInterval() time.Duration
 	LegoMinimumValidity() time.Duration
 	LegoPodIP() net.IP
+	LegoRsaKeySize() int
 	IngressProvider(string) (IngressProvider, error)
 	Version() string
 	AcmeUser() (map[string][]byte, error)

--- a/pkg/mocks/mocks.go
+++ b/pkg/mocks/mocks.go
@@ -217,6 +217,16 @@ func (_mr *_MockKubeLegoRecorder) LegoPodIP() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoPodIP")
 }
 
+func (_m *MockKubeLego) LegoRsaKeySize() int {
+	ret := _m.ctrl.Call(_m, "LegoRsaKeySize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockKubeLegoRecorder) LegoRsaKeySize() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LegoRsaKeySize")
+}
+
 func (_m *MockKubeLego) IngressProvider(_param0 string) (IngressProvider, error) {
 	ret := _m.ctrl.Call(_m, "IngressProvider", _param0)
 	ret0, _ := ret[0].(IngressProvider)


### PR DESCRIPTION
With this change the RSA key size is made configurable.

The given keysize is checked to be a number and to be >= 512... not sure if there should be more checks?

Fixes #111 