### PR TITLE
Fix returning an error in selfcheck

### DIFF
--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -13,11 +13,12 @@ import (
 	"net/url"
 	"sync"
 
+	"time"
+
 	"github.com/cenk/backoff"
 	"github.com/jetstack/kube-lego/pkg/kubelego_const"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/net/context"
-	"time"
 )
 
 func (a *Acme) ensureAcmeClient() error {
@@ -66,9 +67,7 @@ func (a *Acme) testReachablilty(domain string) error {
 	}
 
 	if string(idReceived) != a.id {
-		if err != nil {
-			return fmt.Errorf("received id (%s) did not match expected (%s)", idReceived, a.id)
-		}
+		return fmt.Errorf("received id (%s) did not match expected (%s)", idReceived, a.id)
 	}
 	return nil
 }


### PR DESCRIPTION
Before this change the selfcheck would succeed even if the remote
server was not this instance of kube-lego.