### PR TITLE
Add spec selector to kube-lego/deployment

### DIFF
--- a/examples/nginx/lego/deployment.yaml
+++ b/examples/nginx/lego/deployment.yaml
@@ -3,7 +3,12 @@ kind: Deployment
 metadata:
   name: kube-lego
   namespace: kube-lego
+  labels:
+    app: kube-lego
 spec:
+  selector:
+    matchLabels:
+      app: kube-lego
   replicas: 1
   template:
     metadata:

--- a/examples/nginx/nginx/default-deployment.yaml
+++ b/examples/nginx/nginx/default-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: nginx-ingress
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: default-http-backend
   template:
     metadata:
       labels:

--- a/examples/nginx/nginx/deployment.yaml
+++ b/examples/nginx/nginx/deployment.yaml
@@ -5,10 +5,13 @@ metadata:
   namespace: nginx-ingress
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-ingress
   template:
     metadata:
       labels:
-        app: nginx
+        app: nginx-ingress
     spec:
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3


### PR DESCRIPTION
Kubernetes 1.8 requires that spec.selector be specified. In prior versions, it would use a default value, but they are now disallowing that.

Also, the `apiVersion` should now be "apps/v1beta2", but can change in multiple places later.