### PR TITLE
check only updated ingress's namespace

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -76,8 +76,8 @@ func New(client kubelego.KubeLego, namespace string, name string) *Ingress {
 	return ingress
 }
 
-func All(client kubelego.KubeLego) (ingresses []kubelego.Ingress, err error) {
-	ingSlice, err := client.KubeClient().Extensions().Ingresses(client.LegoWatchNamespace()).List(k8sMeta.ListOptions{})
+func All(client kubelego.KubeLego, namespace string) (ingresses []kubelego.Ingress, err error) {
+	ingSlice, err := client.KubeClient().Extensions().Ingresses(namespace).List(k8sMeta.ListOptions{})
 
 	if err != nil {
 		return

--- a/pkg/kubelego/configure.go
+++ b/pkg/kubelego/configure.go
@@ -79,7 +79,7 @@ func (kl *KubeLego) processProvider(ings []kubelego.Ingress) (err error) {
 	return nil
 }
 
-func (kl *KubeLego) reconfigure(ingressesAll []kubelego.Ingress) error {
+func (kl *KubeLego) reconfigure(ingressesAll []kubelego.Ingress) []error {
 	tlsSlice := []kubelego.Tls{}
 	ingresses := []kubelego.Ingress{}
 
@@ -100,7 +100,16 @@ func (kl *KubeLego) reconfigure(ingressesAll []kubelego.Ingress) error {
 
 	// process certificate validity
 	kl.Log().Info("process certificate requests for ingresses")
-	errs := kl.TlsProcessHosts(tlsSlice)
+	return kl.TlsProcessHosts(tlsSlice)
+}
+
+func (kl *KubeLego) Reconfigure(namespace string) error {
+	ingresses, err := ingress.All(kl, namespace)
+	if err != nil {
+		return err
+	}
+
+	errs := kl.reconfigure(ingresses)
 	if len(errs) > 0 {
 		errsStr := []string{}
 		for _, err := range errs {
@@ -109,19 +118,10 @@ func (kl *KubeLego) reconfigure(ingressesAll []kubelego.Ingress) error {
 		kl.Log().Error("Error while processing certificate requests: ", strings.Join(errsStr, ", "))
 
 		// request a rerun of reconfigure
-		kl.workQueue.Add(true)
+		kl.workQueue.Add(namespace)
 	}
 
 	return nil
-}
-
-func (kl *KubeLego) Reconfigure() error {
-	ingressesAll, err := ingress.All(kl)
-	if err != nil {
-		return err
-	}
-
-	return kl.reconfigure(ingressesAll)
 }
 
 func (kl *KubeLego) TlsProcessHosts(tlsSlice []kubelego.Tls) []error {

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -142,7 +142,7 @@ func (kl *KubeLego) Init() {
 	go func() {
 		for timestamp := range ticker.C {
 			kl.Log().Infof("Periodically check certificates at %s", timestamp)
-			kl.requestReconfigure()
+			kl.requestReconfigure(kl.LegoWatchNamespace())
 		}
 	}()
 


### PR DESCRIPTION
The PR changes the update logic completely and makes it namespace specific. Before an update to an ingress would trigger a check on all ingresses but now it will trigger only for the ingresses in the updated ingress's namespace.

The periodic checks(by default every 8h) will still be applied to all ingresses under configured namespace(if non configured then it is all namespace, which is what we have in production). So nothing changes for it.

This saves a lot of unnecessary runs particularly in bigger clusters with many apps. It also makes kube-lego less vulnerable to domains that fails reachability/acme auth test. Because kube-lego goes through all the domains sequentially, if a domain is failing in the current run the newly added domain that will be processed by kube-lego will have to wait `5m`(default exponential backoff time) + 5 more minutes if in the next run if the failing domain comes before the new domain, in total 10 minutes to get a certificate because of a single failing domain. The PR improves this situation drastically.