### PR TITLE
Do not crash when decoded private key data does not include PEM data

### DIFF
--- a/pkg/acme/acme_e2e_test.go
+++ b/pkg/acme/acme_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"syscall"
 	"testing"
 	"time"
 
@@ -28,7 +29,7 @@ var domain string
 func TestMain(m *testing.M) {
 	logrus.SetLevel(logrus.DebugLevel)
 	setupNgrok()
-	defer cmdNgrok.Process.Kill()
+	defer syscall.Kill(-cmdNgrok.Process.Pid, syscall.SIGKILL)
 	domain = getDomain()
 
 	os.Exit(m.Run())
@@ -56,6 +57,7 @@ func setupMockedKubeLego(t *testing.T) (*mocks.MockKubeLego, *gomock.Controller)
 func setupNgrok() {
 	command := []string{"ngrok", "http", "--bind-tls", "false", "8181"}
 	cmdNgrok = exec.Command(command[0], command[1:]...)
+	cmdNgrok.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	err := cmdNgrok.Start()
 	if err != nil {
 		log.Fatal("failed to start ngrok", err)

--- a/pkg/acme/cert_request.go
+++ b/pkg/acme/cert_request.go
@@ -24,6 +24,7 @@ func (a *Acme) ensureAcmeClient() error {
 	// get existing user or create new one
 	client, accountURI, err := a.getUser()
 	if err != nil {
+		a.Log().Warnf("error while getting existing user: %s. Creating a new one", err)
 		client, account, err := a.createUser()
 		if err != nil {
 			return err

--- a/pkg/acme/user.go
+++ b/pkg/acme/user.go
@@ -77,6 +77,9 @@ func (a *Acme) getUser() (client *acme.Client, accountURI string, err error) {
 		return nil, "", fmt.Errorf("could not find acme private key with key '%s'", kubelego.AcmePrivateKey)
 	}
 	block, _ := pem.Decode(privateKeyData)
+	if block == nil {
+		return nil, "", fmt.Errorf("no PEM data is found after decoding privateKeyData")
+	}
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
kube-lego currently crashes when account private key is correctly encoded. The PR makes sure kube-lego handles this situation gracefully and also introduces an extra test case.

/r @simonswine