### PR TITLE
Update Slack channel name

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Additionally, be aware of the automatically created resources (see environment v
 
 Possible resources for *help*:
 
-* The official channel `#kube-lego` on `kubernetes.slack.com`
+* The official channel ~~`#kube-lego`~~ `#cert-manager` on `kubernetes.slack.com` (The old channel was renamed)
 
 > There is also a good chance to get some support on non-official support
 > channels for *kube-lego*, but be aware that these are rather general


### PR DESCRIPTION
Might be helpful for people looking for help with `kube-lego` or migrations to `cert-manager`. Not sure if this is needed. Feel free to close if this PR is unnecessary or not helpful.