### PR TITLE
Multiple ingress with same secret  Fixes #298

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -83,7 +83,7 @@ func All(client kubelego.KubeLego) (ingresses []kubelego.Ingress, err error) {
 		return
 	}
 
-	for i, _ := range ingSlice.Items {
+	for i := range ingSlice.Items {
 		ingresses = append(
 			ingresses,
 			&Ingress{
@@ -206,11 +206,8 @@ func (i *Ingress) KubeLego() kubelego.KubeLego {
 }
 
 func (i *Ingress) Tls() (out []kubelego.Tls) {
-	for count, _ := range i.IngressApi.Spec.TLS {
-		out = append(out, &Tls{
-			IngressTLS: &i.IngressApi.Spec.TLS[count],
-			ingress:    i,
-		})
+	for count := range i.IngressApi.Spec.TLS {
+		out = append(out, NewTls(&i.IngressApi.Spec.TLS[count], i))
 	}
 	return
 }

--- a/pkg/ingress/tls.go
+++ b/pkg/ingress/tls.go
@@ -15,8 +15,6 @@ import (
 	k8sExtensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
-var _ kubelego.Tls = &Tls{}
-
 type Tls struct {
 	namespace  string
 	name       string
@@ -78,6 +76,15 @@ func (t *Tls) Secret() kubelego.Secret {
 
 func (t *Tls) Hosts() []string {
 	return t.hosts
+}
+func (t *Tls) AddHost(host string) {
+	for _, h := range t.hosts {
+		if h == host {
+			return
+		}
+	}
+
+	t.hosts = append(t.hosts, host)
 }
 
 func (t *Tls) Log() *logrus.Entry {

--- a/pkg/ingress/tls_test.go
+++ b/pkg/ingress/tls_test.go
@@ -3,9 +3,12 @@ package ingress
 import (
 	"testing"
 
+	kubelego "github.com/jetstack/kube-lego/pkg/kubelego_const"
 	"github.com/stretchr/testify/assert"
 	k8sExtensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
+
+var _ kubelego.Tls = &Tls{}
 
 func TestTls_Validate(t *testing.T) {
 	tt := []struct {

--- a/pkg/ingress/tls_test.go
+++ b/pkg/ingress/tls_test.go
@@ -8,36 +8,50 @@ import (
 )
 
 func TestTls_Validate(t *testing.T) {
-	ing := &Ingress{}
-	tlsNoHosts := &Tls{
-		IngressTLS: &k8sExtensions.IngressTLS{
-			SecretName: "my-secret",
+	tt := []struct {
+		name       string
+		secretname string
+		hosts      []string
+		expectErr  bool
+	}{
+		{
+			name:       "no hosts",
+			secretname: "my-secret",
+			hosts:      nil,
+			expectErr:  true,
 		},
-		ingress: ing,
+		{
+			name:       "no secret",
+			secretname: "",
+			hosts:      []string{"das.de.de", "k8s.io"},
+			expectErr:  true,
+		},
+		{
+			name:       "correct tls",
+			secretname: "my-secret",
+			hosts:      []string{"das.de.de", "k8s.io"},
+			expectErr:  false,
+		},
 	}
 
-	tlsNoSecretName := &Tls{
-		IngressTLS: &k8sExtensions.IngressTLS{
-			Hosts: []string{"das.de.de", "k8s.io"},
-		},
-		ingress: ing,
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ing := &Ingress{}
+			tls := NewTls(
+				&k8sExtensions.IngressTLS{
+					Hosts:      tc.hosts,
+					SecretName: tc.secretname,
+				},
+				ing,
+			)
+
+			err := tls.Validate()
+			if tc.expectErr {
+				assert.NotNil(t, err, "validate fails for ", tc.name)
+			} else {
+				assert.Nil(t, err, "validate fails for ", tc.name)
+			}
+		})
 	}
-
-	tls := &Tls{
-		IngressTLS: &k8sExtensions.IngressTLS{
-			Hosts:      []string{"das.de.de", "k8s.io"},
-			SecretName: "my-secret",
-		},
-		ingress: ing,
-	}
-
-	err := tlsNoHosts.Validate()
-	assert.NotNil(t, err, "validate fails with no hosts")
-
-	err = tlsNoSecretName.Validate()
-	assert.NotNil(t, err, "validate fails with no secret")
-
-	err = tls.Validate()
-	assert.Nil(t, err, "validates correct tls")
 
 }

--- a/pkg/kubelego/configure_test.go
+++ b/pkg/kubelego/configure_test.go
@@ -20,6 +20,16 @@ func (m *mockTls) Hosts() []string {
 	return m.hosts
 }
 
+func (m *mockTls) AddHost(host string) {
+	for _, h := range m.hosts {
+		if h == host {
+			return
+		}
+	}
+
+	m.hosts = append(m.hosts, host)
+}
+
 func (m *mockTls) SecretMetadata() *k8sApi.ObjectMeta {
 	return &k8sApi.ObjectMeta{
 		Name:      m.SecretName,
@@ -39,8 +49,8 @@ func (m *mockTls) Process() error {
 	return nil
 }
 
-func getTlsExample() []kubelego.Tls {
-	return []kubelego.Tls{
+func getTlsExample() ([]kubelego.Tls, []kubelego.Tls) {
+	inp := []kubelego.Tls{
 		&mockTls{
 			SecretName:  "secret1",
 			IngressName: "ingress1",
@@ -66,11 +76,34 @@ func getTlsExample() []kubelego.Tls {
 			hosts:       []string{"domain1"},
 		},
 	}
+
+	out := []kubelego.Tls{
+		&mockTls{
+			SecretName:  "secret1",
+			IngressName: "ingress1",
+			Namespace:   "namespace1",
+			hosts:       []string{"domain1"},
+		},
+		&mockTls{
+			SecretName:  "secret2",
+			IngressName: "ingress2",
+			Namespace:   "namespace1",
+			hosts:       []string{"domain2"},
+		},
+		&mockTls{
+			SecretName:  "secret1",
+			IngressName: "ingress3",
+			Namespace:   "namespace2",
+			hosts:       []string{"domain3", "domain4"},
+		},
+	}
+
+	return inp, out
 }
 
 func TestKubeLego_TlsIgnoreDuplicatedSecrets(t *testing.T) {
 	k := New("test")
-	input := getTlsExample()
+	input, expected := getTlsExample()
 	output := k.TlsIgnoreDuplicatedSecrets(input)
-	assert.EqualValues(t, 2, len(output))
+	assert.ElementsMatch(t, output, expected)
 }

--- a/pkg/kubelego_const/interfaces.go
+++ b/pkg/kubelego_const/interfaces.go
@@ -46,6 +46,7 @@ type Acme interface {
 
 type Tls interface {
 	Hosts() []string
+	AddHost(string)
 	SecretMetadata() *k8sApi.ObjectMeta
 	IngressMetadata() *k8sApi.ObjectMeta
 	Process() error

--- a/pkg/mocks/mocks.go
+++ b/pkg/mocks/mocks.go
@@ -425,6 +425,16 @@ func (mr *MockTlsMockRecorder) Hosts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hosts", reflect.TypeOf((*MockTls)(nil).Hosts))
 }
 
+// AddHost mocks base method
+func (m *MockTls) AddHost(arg0 string) {
+	m.ctrl.Call(m, "AddHost", arg0)
+}
+
+// AddHost indicates an expected call of AddHost
+func (mr *MockTlsMockRecorder) AddHost(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddHost", reflect.TypeOf((*MockTls)(nil).AddHost), arg0)
+}
+
 // SecretMetadata mocks base method
 func (m *MockTls) SecretMetadata() *v1.ObjectMeta {
 	ret := m.ctrl.Call(m, "SecretMetadata")


### PR DESCRIPTION
 Fixes #298 

- Created constructor function for ingress.Tls which extracts required info from k8s.tls.
- Added ability to add host to Tls.
- Changed TlsIgnoreDuplicatedSecrets to accept secret referenced from multiple ingress. But merge hosts from those ingresses. 
