### PR TITLE
Set user agent on default http roundtripper

### DIFF
--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 	"github.com/jetstack/kube-lego/pkg/provider/gce"
 	"github.com/jetstack/kube-lego/pkg/provider/nginx"
 	"github.com/jetstack/kube-lego/pkg/secret"
+	"github.com/jetstack/kube-lego/pkg/utils"
 
 	log "github.com/Sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -97,6 +99,9 @@ func (kl *KubeLego) Init() {
 		logger.Debug("received signal")
 		kl.Stop()
 	}()
+
+	// set user agent on default http client
+	http.DefaultClient.Transport = utils.UserAgentRoundTripper(http.DefaultTransport, kl.Version())
 
 	// parse env vars
 	err := kl.paramsLego()

--- a/pkg/utils/useragent_roundtripper.go
+++ b/pkg/utils/useragent_roundtripper.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"net/http"
+)
+
+// KubeLegoUserAgentPrefix is the user agent prefix that http clients in this codebase should use
+var KubeLegoUserAgentPrefix = "jetstack-kube-lego/"
+
+// UserAgentRoundTripper implements the http.RoundTripper interface and adds a User-Agent
+// header.
+type userAgentRoundTripper struct {
+	version string
+
+	inner http.RoundTripper
+}
+
+// UserAgentRoundTripper returns a RoundTripper that functions identically to
+// the provided 'inner' round tripper, other than also setting a user agent.
+func UserAgentRoundTripper(inner http.RoundTripper, version string) http.RoundTripper {
+	return userAgentRoundTripper{
+		version: version,
+		inner:   inner,
+	}
+}
+
+// RoundTrip implements http.RoundTripper
+func (u userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("User-Agent", KubeLegoUserAgentPrefix+u.version)
+	return u.inner.RoundTrip(req)
+}


### PR DESCRIPTION
This PR sets the user agent on the default HTTP roundtripper to help Letsencrypt diagnose abusive traffic patterns (reported here: https://github.com/jetstack/cert-manager/issues/407)

/cc @simonswine @jsha