### PR TITLE
Fix link to cert-manager migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >  features. The latest Kubernetes release that kube-lego officially supports
 >  is **1.8**.  The officially endorsed successor is **[cert-manager](https://github.com/jetstack/cert-manager/)**.
 >
->  If you are a current user of kube-lego, you can find a migration guide [here](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/migrating-from-kube-lego.md).
+>  If you are a current user of kube-lego, you can find a migration guide [here](https://cert-manager.readthedocs.io/en/latest/tutorials/acme/migrating-from-kube-lego.html).
 >
 >  :warning:
 


### PR DESCRIPTION
Old link was 404