### PR TITLE
Adjust controller to process one ingress at a time. Use per-item rate limiting workqueue.

### DIFF
--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -52,7 +52,7 @@ func IgnoreIngress(ing *k8sExtensions.Ingress) error {
 
 func New(client kubelego.KubeLego, namespace string, name string) *Ingress {
 	ingress := &Ingress{
-		exists:   true,
+		Exists:   true,
 		kubelego: client,
 	}
 
@@ -66,7 +66,7 @@ func New(client kubelego.KubeLego, namespace string, name string) *Ingress {
 					Name:      name,
 				},
 			}
-			ingress.exists = false
+			ingress.Exists = false
 
 		} else {
 			client.Log().Warn("Error while getting ingress: ", err)
@@ -88,7 +88,7 @@ func All(client kubelego.KubeLego) (ingresses []kubelego.Ingress, err error) {
 			ingresses,
 			&Ingress{
 				IngressApi: &ingSlice.Items[i],
-				exists:     true,
+				Exists:     true,
 				kubelego:   client,
 			},
 		)
@@ -100,7 +100,7 @@ var _ kubelego.Ingress = &Ingress{}
 
 type Ingress struct {
 	IngressApi *k8sExtensions.Ingress
-	exists     bool
+	Exists     bool
 	kubelego   kubelego.KubeLego
 }
 
@@ -125,14 +125,14 @@ func (o *Ingress) Save() (err error) {
 
 	// check if it contains rules
 	if len(o.IngressApi.Spec.Rules) > 0 {
-		if o.exists {
+		if o.Exists {
 			obj, err = o.client().Update(o.IngressApi)
 		} else {
 			obj, err = o.client().Create(o.IngressApi)
-			o.exists = true
+			o.Exists = true
 		}
 	} else {
-		if o.exists {
+		if o.Exists {
 			err = o.client().Delete(o.IngressApi.Namespace, &k8sMeta.DeleteOptions{})
 			obj = nil
 		}
@@ -146,7 +146,7 @@ func (o *Ingress) Save() (err error) {
 
 func (i *Ingress) Delete() error {
 
-	if i.IngressApi == nil || !i.exists {
+	if i.IngressApi == nil || !i.Exists {
 		return nil
 	}
 

--- a/pkg/kubelego/configure.go
+++ b/pkg/kubelego/configure.go
@@ -93,9 +93,6 @@ func (kl *KubeLego) reconfigure(ing kubelego.Ingress) error {
 			errsStr = append(errsStr, fmt.Sprintf("%s", err))
 		}
 		kl.Log().Error("Error while processing certificate requests: ", strings.Join(errsStr, ", "))
-
-		// request a rerun of reconfigure
-		kl.workQueue.Add(true)
 	}
 
 	return nil

--- a/pkg/kubelego/type.go
+++ b/pkg/kubelego/type.go
@@ -50,5 +50,5 @@ type KubeLego struct {
 	waitGroup sync.WaitGroup
 
 	// work queue
-	workQueue *workqueue.Type
+	workQueue workqueue.RateLimitingInterface
 }

--- a/pkg/kubelego/watch.go
+++ b/pkg/kubelego/watch.go
@@ -111,7 +111,8 @@ func (kl *KubeLego) WatchEvents() {
 				kl.Log().Errorf("worker: failed to key ingress: %v", err)
 				return
 			} else {
-				kl.workQueue.AddRateLimited(key)
+				kl.Log().Infof("Queued item %q to be processed immediately", key)
+				kl.workQueue.Add(key)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -124,6 +125,7 @@ func (kl *KubeLego) WatchEvents() {
 				kl.Log().Errorf("worker: failed to key ingress: %v", err)
 				return
 			} else {
+				kl.Log().Infof("Queued item %q to be processed (delay of 10m)", key)
 				kl.workQueue.AddRateLimited(key)
 			}
 		},
@@ -145,7 +147,8 @@ func (kl *KubeLego) WatchEvents() {
 					kl.Log().Errorf("worker: failed to key ingress: %v", err)
 					return
 				} else {
-					kl.workQueue.AddRateLimited(key)
+					kl.Log().Infof("Detected deleted ingress %q - skipping", key)
+					// kl.workQueue.Add(key)
 				}
 			}
 		},


### PR DESCRIPTION
This is in relation to https://github.com/jetstack/cert-manager/issues/407

From that issue:

> Based on the code in WatchEvents (https://github.com/jetstack/kube-lego/blob/master/pkg/kubelego/watch.go#L73) - it appears that whenever any Kubernetes Ingress resource is created, updated, or deleted, all Ingress resources are immediately scheduled for re-processing.
>
> Ingresses that already have a valid certificate will be skipped, but any user with a number of failing/invalid ingresses will make requests to LE APIs in an attempt to validate those ingresses.
>
> As part of those syncs, more updates will likely be made to ingresses, thus re-queuing these ingresses to be immediately reprocessed after the 'round' of processing ingresses fails.
>
> The good news is we do only process one Ingress resource at a time, which should reduce the hits to the API somewhat (this could be a lot worse otherwise).

This PR changes the usage of the workqueue to only process one ingress at a time. It also switches the workqueue to use the rate limiting interface instead of a plain workqueue. This allows us to exponentially backoff validation attempts on a per ingress basis.

~**NOTE**: I have not run e2e tests against this patch yet - I will update this PR with results once I have~

/cc @jsha @simonswine 

ref #328 
