### PR TITLE
Revert "Skip acme e2e test due to LE staging downtime"

### DIFF
--- a/pkg/acme/acme_e2e_test.go
+++ b/pkg/acme/acme_e2e_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestAcme_E2E(t *testing.T) {
-	t.Skip("Temporarily skipping due to Let's Encrypt staging outage")
 	logrus.SetLevel(logrus.DebugLevel)
 	log := logrus.WithField("context", "test-mock")
 


### PR DESCRIPTION
Reverts jetstack/kube-lego#331