### PR TITLE
Pass the ingress object, not the function to renew

### DIFF
--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -147,7 +147,9 @@ func (kl *KubeLego) Init() {
 	go func() {
 		for timestamp := range ticker.C {
 			kl.Log().Infof("Periodically check certificates at %s", timestamp)
-			kl.requestReconfigure()
+			if err := kl.requestReconfigure(); err != nil {
+				kl.Log().Errorf("Error requesting reconfigure of certificates: %s", err)
+			}
 		}
 	}()
 

--- a/pkg/kubelego/watch.go
+++ b/pkg/kubelego/watch.go
@@ -35,7 +35,7 @@ func (kl *KubeLego) requestReconfigure() error {
 		return err
 	}
 	for _, ing := range allIng {
-		key, err := cache.MetaNamespaceKeyFunc(ing.Object)
+		key, err := cache.MetaNamespaceKeyFunc(ing.Object())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes auto-renewal of certificates and exposes any future errors.