### PR TITLE
Fix user registration for e2e test

### DIFF
--- a/pkg/acme/acme_e2e_test.go
+++ b/pkg/acme/acme_e2e_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestAcme_E2E(t *testing.T) {
-	t.Skip("Temporarily skipping due to Let's Encrypt staging outage")
 	logrus.SetLevel(logrus.DebugLevel)
 	log := logrus.WithField("context", "test-mock")
 
@@ -29,7 +28,7 @@ func TestAcme_E2E(t *testing.T) {
 	mockKL.EXPECT().LegoHTTPPort().AnyTimes().Return(intstr.FromInt(8181))
 	mockKL.EXPECT().AcmeUser().MinTimes(1).Return(nil, errors.New("I am only mocked"))
 	mockKL.EXPECT().LegoURL().MinTimes(1).Return("https://acme-staging.api.letsencrypt.org/directory")
-	mockKL.EXPECT().LegoEmail().MinTimes(1).Return("kube-lego-e2e@example.com")
+	mockKL.EXPECT().LegoEmail().MinTimes(1).Return("kube-lego-e2e@jetstack.io")
 	mockKL.EXPECT().SaveAcmeUser(gomock.Any()).MinTimes(1).Return(nil)
 	mockKL.EXPECT().LegoRsaKeySize().AnyTimes().Return(2048)
 	mockKL.EXPECT().ExponentialBackoffMaxElapsedTime().MinTimes(1).Return(time.Minute * 5)


### PR DESCRIPTION
Re-enables the e2e test now that Let's Encrypt Staging is working.
Changes user email domain now that Let's Encrypt no longer allows users with the domain example.com.